### PR TITLE
Fixed issue with double click

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -64,6 +64,11 @@ chrome.extension.sendMessage({}, function(response) {
           e.preventDefault();
           e.stopPropagation();
         }, true);
+
+        container.addEventListener('dblclick', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+        }, true);
       }
 
       function runAction(action) {


### PR DESCRIPTION
Regarding our [conversation on Twitter](https://twitter.com/igrigorik/status/440543072351301632), I've tested locally and figured out how to prevent YouTube from entering full screen mode when clicking on your controls. We just had to prevent the "dblclick" event from bubbling up. I've added a handler that does that. 

(You can download my fork and [test it in Chrome locally](https://developer.chrome.com/extensions/getstarted#unpacked) if you want to check if it works.)
