### PR TITLE
Fixed full screen issue on Vimeo

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -65,10 +65,17 @@ chrome.extension.sendMessage({}, function(response) {
           e.stopPropagation();
         }, true);
 
+        // Prevent full screen mode on YouTube
         container.addEventListener('dblclick', function(e) {
           e.preventDefault();
           e.stopPropagation();
         }, true);
+
+        // Prevent full screen mode on Vimeo
+        container.addEventListener('mousedown', function(e) {
+          e.preventDefault();
+          e.stopPropagation();
+        }, true);        
       }
 
       function runAction(action) {


### PR DESCRIPTION
In response to your message in [issue #1](https://github.com/igrigorik/videospeed/pull/1#issuecomment-36558009), it turns out that we have to kill "mousedown" on Vimeo in order to prevent full screen mode.

(This also fixes the issue where clicking on your controls pauses the video.) 
