### PR TITLE
SpeedIndicator value reset when navigating to related videos on YouTube

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -12,6 +12,17 @@ chrome.extension.sendMessage({}, function(response) {
         this.video.addEventListener('ratechange', function(event) {
           this.speedIndicator.textContent = this.getSpeed();
         }.bind(this));
+
+        // Resets speedIndicator display when src changes (e.g. youtube doesn't reload page)
+        this.observer = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation) {
+            if (mutation.attributeName.toLowerCase() == 'src') {
+              self.speedIndicator.textContent = '1.00';
+            }
+          });
+        });
+        self = this;
+        this.observer.observe(this.video, {attributes: true, attributeFilter: ['src']});
       };
 
       tc.videoController.prototype.getSpeed = function() {


### PR DESCRIPTION
## Issue

When navigating to other videos on youtube, videos are changed via AJAX. Even though the speed of the video is reset*, the speedIndicator does not reflect this.
## Solution

YouTube does not create a new DOM node or refresh the page, instead just changes the video source.
Therefore, added a MutationObserver on the video src to reset the speedIndicator text. 
This will work on video tags anywhere that follow this pattern.

(I don't work in JS too much, so if I did anything sub-optimally, lemme know.)

*I think this is the correct behavior, though an enhancement might be to add a "sticky speed" configuration to maintain the same modified speed across all future videos until further notice. Not sure how useful that would be.
