### PR TITLE
Add *Actual speed* feature request

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note that you can customize these shortcuts in the extension settings page. Also
 ### Wishlist
 
 * Make it not suck with Vimeo content: "s" shortcut and button clicks
+* Show actual playback speed
 * Your awesome feature here...
 
 


### PR DESCRIPTION
When playing videos in really high speed (eg. 100x, yes, with some #solareclipse videos I've done that), it's actually played slower. Maybe my HW is not capable to render video stream that fast or what... I wish to know what was actual playback speed, because it looks it was only ~10x faster.