### PR TITLE
Update our speed setting when the speed is changed externally.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -44,6 +44,9 @@ chrome.extension.sendMessage({}, function(response) {
         });
 
         target.addEventListener('ratechange', function(event) {
+          if (target.readyState === 0) {
+            return;
+          }
           var speed = this.getSpeed();
           this.speedIndicator.textContent = speed;
           tc.settings.speed = speed;

--- a/inject.js
+++ b/inject.js
@@ -46,6 +46,8 @@ chrome.extension.sendMessage({}, function(response) {
         target.addEventListener('ratechange', function(event) {
           var speed = this.getSpeed();
           this.speedIndicator.textContent = speed;
+          tc.settings.speed = speed;
+          chrome.storage.sync.set({'speed': speed});
         }.bind(this));
 
         target.playbackRate = tc.settings.speed;
@@ -126,8 +128,6 @@ chrome.extension.sendMessage({}, function(response) {
 
       function setSpeed(v, speed) {
         v.playbackRate = speed;
-        tc.settings.speed = speed;
-        chrome.storage.sync.set({'speed': speed});
       }
 
       function runAction(action) {


### PR DESCRIPTION
e.g. Coursera videos have their own speed controls. If the speed
is changed from A to B via their controls, then the video is
paused & resumed, our play callback would reset the speed to A.

We now ensure our speed setting is accurate by updating it in the
ratechange callback, which happens no matter how the speed is
updated.