### PR TITLE
Add new hangouts.google.com URL to excluded matches.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,7 @@
       "matches": [ "http://*/*", "https://*/*", "file:///*"],
       "exclude_matches": [
         "https://plus.google.com/hangouts/*",
+        "https://hangouts.google.com/hangouts/*",
         "http://www.lynda.com/*",
         "http://www.hitbox.tv/*"
       ],


### PR DESCRIPTION
Sometimes, but not all the time, I end up at hangouts.google.com instead
of plus.google.com. I think this is part of Google's move to decouple
Google Plus from the Hangouts service.

Resolves #81.