### PR TITLE
Check for document before checking for readyState

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -122,7 +122,7 @@ chrome.extension.sendMessage({}, function(response) {
 
   function initializeWhenReady(document) {
     var readyStateCheckInterval = setInterval(function() {
-      if (document.readyState === 'complete') {
+      if (document && document.readyState === 'complete') {
         clearInterval(readyStateCheckInterval);
         initializeNow(document);
       }


### PR DESCRIPTION
Every now and then this fires before the document is ready and I end up with this error going nuts in my console: 

![](http://wes.io/gQdm/content)

Pretty sure this happens because the check happens even before the document exists. 