### PR TITLE
Move controller on YT using relative positioning

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -2,7 +2,8 @@
 
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {
-  margin-top: 10px;
+  position: relative;
+  top: 10px;
 }
 
 .ytp-autohide .vsc-controller {
@@ -19,12 +20,14 @@
 /* YouTube embedded player */
 /* e.g. https://www.igvita.com/2012/09/12/web-fonts-performance-making-pretty-fast/ */
 .full-frame .html5-video-player:not(.ytp-fullscreen) .vsc-controller {
-  margin-top: 45px;
+  position: relative;
+  top: 45px;
 }
 
 .ytp-fullscreen .vsc-controller {
   display: block;
-  margin-top: 60px;
+  position: relative;
+  top: 60px;
 }
 
 /* shift controller on vine.co */


### PR DESCRIPTION
There was a black bar issue on YT reported at #115. This should fix that issue by using `relative` positioning and the `top` style attribute.

![image](https://cloud.githubusercontent.com/assets/2940142/16255174/29e2b720-37fc-11e6-8356-1dbf2ef617f6.png)
