### PR TITLE
Removed default parameter value initialization to support old version browsers

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -203,7 +203,7 @@ chrome.extension.sendMessage({}, function(response) {
       });
   }
 
-  function runAction(action, document, keyboard = false) {
+  function runAction(action, document, keyboard) {
     var videoTags = document.getElementsByTagName('video');
     videoTags.forEach = Array.prototype.forEach;
 


### PR DESCRIPTION
Recently videospeed extension stopped working. Even few reported in the chrome store reviews section. This was due to the *default parameter value* for `keyboard = false`. This is not supported in old browsers https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Default_parameters#Browser_compatibility 

So I just removed `= false` for keyboard parameter. Even though if we don't assign any value it gets assigned to `undefined` which is a falsy value.

I know better solution is to update chrome but unfortunately I'm not able to update 32-bit chrome, need to install 64bit OS. :p 