### PR TITLE
add turbo speed for faster speed changing

### DIFF
--- a/options.html
+++ b/options.html
@@ -57,6 +57,10 @@
           <input id="speedStep" type="text" value=""/>
       </div>
       <div class="row">
+          <label for="turboSpeedStep">Turbo Speed Change Step</label>
+          <input id="turboSpeedStep" type="text" value=""/>
+      </div>
+      <div class="row">
           <label for="rememberSpeed">Remember Playback Speed</label>
           <input id="rememberSpeed" type="checkbox"/>
       </div>

--- a/options.js
+++ b/options.js
@@ -1,6 +1,7 @@
 var tcDefaults = {
   speed: 1.0,           // default 1x
   speedStep: 0.1,       // default 0.1x
+  turboSpeedStep: 3.0,  // default 3.0x
   rewindTime: 10,       // default 10s
   advanceTime: 10,      // default 10s
   resetKeyCode:  82,    // default: R
@@ -90,6 +91,7 @@ function updateShortcutInputText(inputId, keyCode) {
 function save_options() {
 
   var speedStep     = document.getElementById('speedStep').value;
+  var turboSpeedStep = document.getElementById('turboSpeedStep').value;
   var rewindTime    = document.getElementById('rewindTime').value;
   var advanceTime   = document.getElementById('advanceTime').value;
   var resetKeyCode  = document.getElementById('resetKeyInput').keyCode;
@@ -103,6 +105,7 @@ function save_options() {
   var blacklist     = document.getElementById('blacklist').value;
 
   speedStep     = isNaN(speedStep) ? tcDefaults.speedStep : Number(speedStep);
+  turboSpeedStep = Math.max(speedStep, isNaN(turboSpeedStep) ? tcDefaults.turboSpeedStep : Number(turboSpeedStep));
   rewindTime    = isNaN(rewindTime) ? tcDefaults.rewindTime : Number(rewindTime);
   advanceTime   = isNaN(advanceTime) ? tcDefaults.advanceTime : Number(advanceTime);
   resetKeyCode  = isNaN(resetKeyCode) ? tcDefaults.resetKeyCode : resetKeyCode;
@@ -114,6 +117,7 @@ function save_options() {
 
   chrome.storage.sync.set({
     speedStep:      speedStep,
+    turboSpeedStep: turboSpeedStep,
     rewindTime:     rewindTime,
     advanceTime:    advanceTime,
     resetKeyCode:   resetKeyCode,
@@ -139,6 +143,7 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get(tcDefaults, function(storage) {
     document.getElementById('speedStep').value = storage.speedStep.toFixed(2);
+    document.getElementById('turboSpeedStep').value = storage.turboSpeedStep.toFixed(2);
     document.getElementById('rewindTime').value = storage.rewindTime;
     document.getElementById('advanceTime').value = storage.advanceTime;
     updateShortcutInputText('resetKeyInput',  storage.resetKeyCode);
@@ -187,4 +192,5 @@ document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('rewindTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('advanceTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('speedStep').addEventListener('keypress', inputFilterNumbersOnly);
+  document.getElementById('turboSpeedStep').addEventListener('keypress', inputFilterNumbersOnly);
 })


### PR DESCRIPTION
Holding Shift and pressing the increase/decrease keys changes the speed in larger steps. I press Shift+D to quickly skim a video until a point where I think it is interesting. Then I press Shift+S or R.

I felt it natural that holding Shift should increase the step size by which the speed is changed.

The reason I chose the default value of 3.0x is that in Chrome and on Youtube the audio is cut off for playback above 4x (1x+3x).

Note that this will break the workarounds suggested for issues like #69.