### PR TITLE
use mouse wheel scroll to increase/decrease speed

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -121,6 +121,13 @@ chrome.extension.sendMessage({}, function(response) {
         </div>
       `;
       shadow.innerHTML = shadowTemplate;
+      shadow.querySelector('#controller').addEventListener('wheel', (e) => {
+        runAction(e.wheelDelta > 0 ? 'faster' : 'slower', document);
+        e.preventDefault();
+        e.stopPropagation();
+      });
+
+
       shadow.querySelector('.draggable').addEventListener('mousedown', (e) => {
         runAction(e.target.dataset['action'], document);
       });


### PR DESCRIPTION
After a few months of use, I realized that despite adjusting the speed frequently, my natural instinct is to use the mouse rather than the keyboard (not sure why; I use keyboard shortcuts all the time).

Here's a little patch that allows you to use the mouse wheel anywhere on the overlay to increase / decrease the speed. Originally, I had it on the `.draggable`, but then I bumped it up to the `#controller` to take advantage of [Fitt's Law][wiki-1] (small increases in target area of a small thing matter more than comparable increases on a large hit area).

[wiki-1]: https://en.wikipedia.org/wiki/Fitts%27s_law