### PR TITLE
Fix browser_action.default_icon paths in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,10 +14,10 @@
   "options_page": "options.html",
   "browser_action": {
     "default_icon": {
-      "19": "images/icon19.png",
-      "38": "images/icon38.png"
+      "19": "icons/icon19.png",
+      "38": "icons/icon38.png",
+      "48": "icons/icon48.png"
     },
-    "default_icon": "icons/icon48.png",
     "default_popup": "popup.html"
   },
   "content_scripts": [{


### PR DESCRIPTION
I was trying to port this to Firefox (as many before me, judging by the commits in some forks) and this was a first thing Mozilla's extension validator complained about.