### PR TITLE
keep per tab speed consistent

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -56,6 +56,18 @@ chrome.extension.sendMessage({}, function(response) {
       }
       this.initializeControls();
 
+      //Save the speed of current tab's video before leaving the page
+      //(ie. reloading page or going Backward/Forward in history)
+      //so that it doesn't restore the speed set by a video in another tab
+      //but instead, keeps the current tab's video speed the same,
+      //until changed by user or browser quits.
+      window.onbeforeunload = function(e) {
+        if (target.readyState === 0) {
+          return;
+        }
+        chrome.storage.sync.set({'speed': this.getSpeed()});
+      }.bind(this);
+
       target.addEventListener('play', function(event) {
         target.playbackRate = tc.settings.speed;
       });


### PR DESCRIPTION
...in the current browser session,
by saving it before navigating away.

Test:
1. open two tabs with videos,
2. set different speeds for each,
3. reload previous (or any) tab.