### PR TITLE
Playback at "fast" speed

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -334,7 +334,7 @@ chrome.extension.sendMessage({}, function(response) {
 
   // CONTRACT: video has a way to set the playback rate.
   function playVideoAtFastSpeed(video) {
-    video.playbackRate = 2.5;
+    video.playbackRate = tc.settings.fastSpeed;
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -4,7 +4,7 @@ chrome.extension.sendMessage({}, function(response) {
       speed: 1.0,           // default 1x
       resetSpeed: 1.0,      // default 1x
       speedStep: 0.1,       // default 0.1x
-      fastSpeed: 1.75,      // default 1.75x
+      fastSpeed: 1.8,       // default 1.8x
       rewindTime: 10,       // default 10s
       advanceTime: 10,      // default 10s
       resetKeyCode:  82,    // default: R

--- a/inject.js
+++ b/inject.js
@@ -332,8 +332,9 @@ chrome.extension.sendMessage({}, function(response) {
     });
   }
 
-  function playVideoAtFastSpeed(videoDomElement) {
-    console.log("playVideoAtFastSpeed", videoDomElement);
+  // CONTRACT: video has a way to set the playback rate.
+  function playVideoAtFastSpeed(video) {
+    video.playbackRate = 2.5;
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -4,6 +4,7 @@ chrome.extension.sendMessage({}, function(response) {
       speed: 1.0,           // default 1x
       resetSpeed: 1.0,      // default 1x
       speedStep: 0.1,       // default 0.1x
+      fastSpeed: 2.5,       // default 2.5x
       rewindTime: 10,       // default 10s
       advanceTime: 10,      // default 10s
       resetKeyCode:  82,    // default: R
@@ -12,6 +13,7 @@ chrome.extension.sendMessage({}, function(response) {
       rewindKeyCode: 90,    // default: Z
       advanceKeyCode: 88,   // default: X
       displayKeyCode: 86,   // default: V
+      playAtFastSpeedKeyCode: 70,    // default: F
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
       blacklist: `

--- a/inject.js
+++ b/inject.js
@@ -13,7 +13,7 @@ chrome.extension.sendMessage({}, function(response) {
       rewindKeyCode: 90,    // default: Z
       advanceKeyCode: 88,   // default: X
       displayKeyCode: 86,   // default: V
-      playAtFastSpeedKeyCode: 70,    // default: F
+      playAtFastSpeedKeyCode: 71,    // default: G
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
       blacklist: `

--- a/inject.js
+++ b/inject.js
@@ -4,7 +4,7 @@ chrome.extension.sendMessage({}, function(response) {
       speed: 1.0,                    // default 1x
       resetSpeed: 1.0,               // default 1x
       speedStep: 0.1,                // default 0.1x
-      fastSpeed: 2.5,                // default 2.5x
+      fastSpeed: 1.75,               // default 1.75x
       rewindTime: 10,                // default 10s
       advanceTime: 10,               // default 10s
       resetKeyCode:  82,             // default: R

--- a/inject.js
+++ b/inject.js
@@ -222,7 +222,7 @@ chrome.extension.sendMessage({}, function(response) {
         } else if (keyCode == tc.settings.displayKeyCode) {
           runAction('display', document, true)
         } else if (keyCode == tc.settings.playAtFastSpeedKeyCode) {
-          playVideoAtFastSpeed();
+          runAction('fast', document, true);
         }
 
         return false;
@@ -325,13 +325,15 @@ chrome.extension.sendMessage({}, function(response) {
           controller.classList.toggle('vsc-hidden');
         } else if (action === 'drag') {
           handleDrag(v, controller);
+        } else if (action === 'fast') {
+          playVideoAtFastSpeed(v);
         }
       }
     });
   }
 
-  function playVideoAtFastSpeed() {
-    console.log("playVideoAtFastSpeed");
+  function playVideoAtFastSpeed(videoDomElement) {
+    console.log("playVideoAtFastSpeed", videoDomElement);
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -13,7 +13,7 @@ chrome.extension.sendMessage({}, function(response) {
       rewindKeyCode: 90,             // default: Z
       advanceKeyCode: 88,            // default: X
       displayKeyCode: 86,            // default: V
-      playAtFastSpeedKeyCode: 71,    // default: G
+      fastKeyCode: 71,               // default: G
       rememberSpeed: false,          // default: false
       startHidden: false,            // default: false
       blacklist: `
@@ -221,7 +221,7 @@ chrome.extension.sendMessage({}, function(response) {
           runAction('reset', document, true)
         } else if (keyCode == tc.settings.displayKeyCode) {
           runAction('display', document, true)
-        } else if (keyCode == tc.settings.playAtFastSpeedKeyCode) {
+        } else if (keyCode == tc.settings.fastKeyCode) {
           runAction('fast', document, true);
         }
 

--- a/inject.js
+++ b/inject.js
@@ -1,21 +1,21 @@
 chrome.extension.sendMessage({}, function(response) {
   var tc = {
     settings: {
-      speed: 1.0,           // default 1x
-      resetSpeed: 1.0,      // default 1x
-      speedStep: 0.1,       // default 0.1x
-      fastSpeed: 2.5,       // default 2.5x
-      rewindTime: 10,       // default 10s
-      advanceTime: 10,      // default 10s
-      resetKeyCode:  82,    // default: R
-      slowerKeyCode: 83,    // default: S
-      fasterKeyCode: 68,    // default: D
-      rewindKeyCode: 90,    // default: Z
-      advanceKeyCode: 88,   // default: X
-      displayKeyCode: 86,   // default: V
+      speed: 1.0,                    // default 1x
+      resetSpeed: 1.0,               // default 1x
+      speedStep: 0.1,                // default 0.1x
+      fastSpeed: 2.5,                // default 2.5x
+      rewindTime: 10,                // default 10s
+      advanceTime: 10,               // default 10s
+      resetKeyCode:  82,             // default: R
+      slowerKeyCode: 83,             // default: S
+      fasterKeyCode: 68,             // default: D
+      rewindKeyCode: 90,             // default: Z
+      advanceKeyCode: 88,            // default: X
+      displayKeyCode: 86,            // default: V
       playAtFastSpeedKeyCode: 71,    // default: G
-      rememberSpeed: false, // default: false
-      startHidden: false,   // default: false
+      rememberSpeed: false,          // default: false
+      startHidden: false,            // default: false
       blacklist: `
         www.instagram.com
         twitter.com

--- a/inject.js
+++ b/inject.js
@@ -221,6 +221,8 @@ chrome.extension.sendMessage({}, function(response) {
           runAction('reset', document, true)
         } else if (keyCode == tc.settings.displayKeyCode) {
           runAction('display', document, true)
+        } else if (keyCode == tc.settings.playAtFastSpeedKeyCode) {
+          playVideoAtFastSpeed();
         }
 
         return false;
@@ -326,6 +328,10 @@ chrome.extension.sendMessage({}, function(response) {
         }
       }
     });
+  }
+
+  function playVideoAtFastSpeed() {
+    console.log("playVideoAtFastSpeed");
   }
 
  function handleDrag(video, controller) {

--- a/inject.js
+++ b/inject.js
@@ -35,6 +35,7 @@ chrome.extension.sendMessage({}, function(response) {
     tc.settings.rewindKeyCode = Number(storage.rewindKeyCode);
     tc.settings.slowerKeyCode = Number(storage.slowerKeyCode);
     tc.settings.fasterKeyCode = Number(storage.fasterKeyCode);
+    tc.settings.fastKeyCode = Number(storage.fastKeyCode);
     tc.settings.displayKeyCode = Number(storage.displayKeyCode);
     tc.settings.advanceKeyCode = Number(storage.advanceKeyCode);
     tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);

--- a/inject.js
+++ b/inject.js
@@ -332,7 +332,6 @@ chrome.extension.sendMessage({}, function(response) {
     });
   }
 
-  // CONTRACT: video has a way to set the playback rate.
   function playVideoAtFastSpeed(video) {
     video.playbackRate = tc.settings.fastSpeed;
   }

--- a/inject.js
+++ b/inject.js
@@ -1,21 +1,21 @@
 chrome.extension.sendMessage({}, function(response) {
   var tc = {
     settings: {
-      speed: 1.0,                    // default 1x
-      resetSpeed: 1.0,               // default 1x
-      speedStep: 0.1,                // default 0.1x
-      fastSpeed: 1.75,               // default 1.75x
-      rewindTime: 10,                // default 10s
-      advanceTime: 10,               // default 10s
-      resetKeyCode:  82,             // default: R
-      slowerKeyCode: 83,             // default: S
-      fasterKeyCode: 68,             // default: D
-      rewindKeyCode: 90,             // default: Z
-      advanceKeyCode: 88,            // default: X
-      displayKeyCode: 86,            // default: V
-      fastKeyCode: 71,               // default: G
-      rememberSpeed: false,          // default: false
-      startHidden: false,            // default: false
+      speed: 1.0,           // default 1x
+      resetSpeed: 1.0,      // default 1x
+      speedStep: 0.1,       // default 0.1x
+      fastSpeed: 1.75,      // default 1.75x
+      rewindTime: 10,       // default 10s
+      advanceTime: 10,      // default 10s
+      resetKeyCode:  82,    // default: R
+      slowerKeyCode: 83,    // default: S
+      fasterKeyCode: 68,    // default: D
+      rewindKeyCode: 90,    // default: Z
+      advanceKeyCode: 88,   // default: X
+      displayKeyCode: 86,   // default: V
+      fastKeyCode: 71,      // default: G
+      rememberSpeed: false, // default: false
+      startHidden: false,   // default: false
       blacklist: `
         www.instagram.com
         twitter.com

--- a/inject.js
+++ b/inject.js
@@ -29,6 +29,7 @@ chrome.extension.sendMessage({}, function(response) {
     tc.settings.speed = Number(storage.speed);
     tc.settings.resetSpeed = Number(storage.resetSpeed);
     tc.settings.speedStep = Number(storage.speedStep);
+    tc.settings.fastSpeed = Number(storage.fastSpeed);
     tc.settings.rewindTime = Number(storage.rewindTime);
     tc.settings.advanceTime = Number(storage.advanceTime);
     tc.settings.resetKeyCode = Number(storage.resetKeyCode);

--- a/options.html
+++ b/options.html
@@ -33,7 +33,7 @@
         <input id="fasterKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
-        <label for="fastKeyInput">Jump to Preferred Fast speed</label>
+        <label for="fastKeyInput">Preferred speed</label>
         <input id="fastKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
@@ -61,7 +61,7 @@
           <input id="speedStep" type="text" value=""/>
       </div>
       <div class="row">
-          <label for="fastSpeed">Preferred Fast Playback Speed (x)</label>
+          <label for="fastSpeed">Preferred Speed (x)</label>
           <input id="fastSpeed" type="text" value=""/>
       </div>
       <div class="row">

--- a/options.html
+++ b/options.html
@@ -33,6 +33,10 @@
         <input id="fasterKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
+        <label for="fastKeyInput">Jump to Preset "Fast" speed</label>
+        <input id="fastKeyInput" placeholder="press a key" type="text" value=""/>
+      </div>
+      <div class="row">
         <label for="displayKeyInput">Show/hide controller</label>
         <input id="displayKeyInput" placeholder="press a key" type="text" value=""/>
       </div>

--- a/options.html
+++ b/options.html
@@ -33,7 +33,7 @@
         <input id="fasterKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
-        <label for="fastKeyInput">Jump to Preset "Fast" speed</label>
+        <label for="fastKeyInput">Jump to Preferred Fast speed</label>
         <input id="fastKeyInput" placeholder="press a key" type="text" value=""/>
       </div>
       <div class="row">
@@ -59,6 +59,10 @@
       <div class="row">
           <label for="speedStep">Speed Change Step</label>
           <input id="speedStep" type="text" value=""/>
+      </div>
+      <div class="row">
+          <label for="fastSpeed">Preferred Fast Playback Speed (x)</label>
+          <input id="fastSpeed" type="text" value=""/>
       </div>
       <div class="row">
           <label for="rememberSpeed">Remember Playback Speed</label>

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ var tcDefaults = {
   speedStep: 0.1,       // default 0.1x
   rewindTime: 10,       // default 10s
   advanceTime: 10,      // default 10s
+  fastSpeed: 1.75,      // default 1.75x
   resetKeyCode:  82,    // default: R
   slowerKeyCode: 83,    // default: S
   fasterKeyCode: 68,    // default: D
@@ -93,6 +94,7 @@ function save_options() {
   var speedStep     = document.getElementById('speedStep').value;
   var rewindTime    = document.getElementById('rewindTime').value;
   var advanceTime   = document.getElementById('advanceTime').value;
+  var fastSpeed     = document.getElementById('fastSpeed').value;
   var resetKeyCode  = document.getElementById('resetKeyInput').keyCode;
   var rewindKeyCode = document.getElementById('rewindKeyInput').keyCode;
   var advanceKeyCode = document.getElementById('advanceKeyInput').keyCode;
@@ -107,6 +109,7 @@ function save_options() {
   speedStep     = isNaN(speedStep) ? tcDefaults.speedStep : Number(speedStep);
   rewindTime    = isNaN(rewindTime) ? tcDefaults.rewindTime : Number(rewindTime);
   advanceTime   = isNaN(advanceTime) ? tcDefaults.advanceTime : Number(advanceTime);
+  fastSpeed     = isNaN(fastSpeed) ? tcDefaults.fastSpeed : Number(fastSpeed);
   resetKeyCode  = isNaN(resetKeyCode) ? tcDefaults.resetKeyCode : resetKeyCode;
   rewindKeyCode = isNaN(rewindKeyCode) ? tcDefaults.rewindKeyCode : rewindKeyCode;
   advanceKeyCode = isNaN(advanceKeyCode) ? tcDefaults.advanceKeyCode : advanceKeyCode;
@@ -119,6 +122,7 @@ function save_options() {
     speedStep:      speedStep,
     rewindTime:     rewindTime,
     advanceTime:    advanceTime,
+    fastSpeed:      fastSpeed,
     resetKeyCode:   resetKeyCode,
     rewindKeyCode:  rewindKeyCode,
     advanceKeyCode: advanceKeyCode,
@@ -145,6 +149,7 @@ function restore_options() {
     document.getElementById('speedStep').value = storage.speedStep.toFixed(2);
     document.getElementById('rewindTime').value = storage.rewindTime;
     document.getElementById('advanceTime').value = storage.advanceTime;
+    document.getElementById('fastSpeed').value = storage.fastSpeed;
     updateShortcutInputText('resetKeyInput',  storage.resetKeyCode);
     updateShortcutInputText('rewindKeyInput', storage.rewindKeyCode);
     updateShortcutInputText('advanceKeyInput', storage.advanceKeyCode);
@@ -193,4 +198,5 @@ document.addEventListener('DOMContentLoaded', function () {
   document.getElementById('rewindTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('advanceTime').addEventListener('keypress', inputFilterNumbersOnly);
   document.getElementById('speedStep').addEventListener('keypress', inputFilterNumbersOnly);
+  document.getElementById('fastSpeed').addEventListener('keypress', inputFilterNumbersOnly);
 })

--- a/options.js
+++ b/options.js
@@ -6,6 +6,7 @@ var tcDefaults = {
   resetKeyCode:  82,    // default: R
   slowerKeyCode: 83,    // default: S
   fasterKeyCode: 68,    // default: D
+  fastKeyCode: 71,      // default: G
   rewindKeyCode: 90,    // default: Z
   advanceKeyCode: 88,   // default: X
   displayKeyCode: 86,   // default: V
@@ -97,6 +98,7 @@ function save_options() {
   var advanceKeyCode = document.getElementById('advanceKeyInput').keyCode;
   var slowerKeyCode = document.getElementById('slowerKeyInput').keyCode;
   var fasterKeyCode = document.getElementById('fasterKeyInput').keyCode;
+  var fastKeyCode   = document.getElementById('fastKeyInput').keyCode;
   var displayKeyCode = document.getElementById('displayKeyInput').keyCode;
   var rememberSpeed = document.getElementById('rememberSpeed').checked;
   var startHidden = document.getElementById('startHidden').checked;
@@ -110,6 +112,7 @@ function save_options() {
   advanceKeyCode = isNaN(advanceKeyCode) ? tcDefaults.advanceKeyCode : advanceKeyCode;
   slowerKeyCode = isNaN(slowerKeyCode) ? tcDefaults.slowerKeyCode : slowerKeyCode;
   fasterKeyCode = isNaN(fasterKeyCode) ? tcDefaults.fasterKeyCode : fasterKeyCode;
+  fastKeyCode   = isNaN(fastKeyCode) ? tcDefaults.fastKeyCode : fastKeyCode;
   displayKeyCode = isNaN(displayKeyCode) ? tcDefaults.displayKeyCode : displayKeyCode;
 
   chrome.storage.sync.set({
@@ -121,6 +124,7 @@ function save_options() {
     advanceKeyCode: advanceKeyCode,
     slowerKeyCode:  slowerKeyCode,
     fasterKeyCode:  fasterKeyCode,
+    fastKeyCode:    fastKeyCode,
     displayKeyCode: displayKeyCode,
     rememberSpeed:  rememberSpeed,
     startHidden:    startHidden,
@@ -146,6 +150,7 @@ function restore_options() {
     updateShortcutInputText('advanceKeyInput', storage.advanceKeyCode);
     updateShortcutInputText('slowerKeyInput', storage.slowerKeyCode);
     updateShortcutInputText('fasterKeyInput', storage.fasterKeyCode);
+    updateShortcutInputText('fastKeyInput', storage.fastKeyCode);
     updateShortcutInputText('displayKeyInput', storage.displayKeyCode);
     document.getElementById('rememberSpeed').checked = storage.rememberSpeed;
     document.getElementById('startHidden').checked = storage.startHidden;
@@ -182,6 +187,7 @@ document.addEventListener('DOMContentLoaded', function () {
   initShortcutInput('advanceKeyInput');
   initShortcutInput('slowerKeyInput');
   initShortcutInput('fasterKeyInput');
+  initShortcutInput('fastKeyInput');
   initShortcutInput('displayKeyInput');
 
   document.getElementById('rewindTime').addEventListener('keypress', inputFilterNumbersOnly);

--- a/options.js
+++ b/options.js
@@ -3,7 +3,7 @@ var tcDefaults = {
   speedStep: 0.1,       // default 0.1x
   rewindTime: 10,       // default 10s
   advanceTime: 10,      // default 10s
-  fastSpeed: 1.75,      // default 1.75x
+  fastSpeed: 1.8,       // default 1.8x
   resetKeyCode:  82,    // default: R
   slowerKeyCode: 83,    // default: S
   fasterKeyCode: 68,    // default: D


### PR DESCRIPTION
By pressing "G", the viewer can play the video at a "fast" speed. If people like this, then we could give them a configuration setting to choose their own "fast" speed.

I wanted this because I was watching a bunch of online training videos and I wanted to just jump to 2.5x speed for every new video in the course.
