### PR TITLE
Allow IntelliJ IDEA for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+
+# IntelliJ IDEA
+.idea/


### PR DESCRIPTION
It's probably easiest just to ignore everything from IDEA, so that the project doesn't accidentally depend on anything in its metadata files.