### PR TITLE
add small delay to scroll to adjust speed

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -125,6 +125,23 @@ chrome.extension.sendMessage({}, function(response) {
         </div>
       `;
       shadow.innerHTML = shadowTemplate;
+      shadow.querySelector('#controller').addEventListener('mouseover', (e) => {
+        let adjustSpeedOnScroll = (e) => {
+          runAction(e.wheelDelta > 0 ? 'faster' : 'slower', document);
+          e.preventDefault();
+          e.stopPropagation();
+        }
+
+        let listenerTimeout = setTimeout(() => {
+          shadow.querySelector('#controller').addEventListener('wheel', adjustSpeedOnScroll)
+        }, 500)
+
+        shadow.querySelector('#controller').addEventListener('mouseout', (e) => {
+          clearTimeout(listenerTimeout)
+          shadow.querySelector('#controller').removeEventListener('wheel', adjustSpeedOnScroll)
+        });
+      });
+
       shadow.querySelector('.draggable').addEventListener('mousedown', (e) => {
         runAction(e.target.dataset['action'], document);
       });


### PR DESCRIPTION
I was experiencing the same issue @strabbit described in #188 but on Reddit. Something like this could be used to get the best of both worlds. It adds a small delay to adding the `wheel` event listener, this way it doesn't get accidentally triggered when scrolling down a page but still allows for the functionality. 

I used the scroll to change speed fairly often (once I discovered it) but would also be okay with the feature disappearing, thought I might as well run this by you all the same in case others were enjoying the feature.