### PR TITLE
Use onreadychangestate event for script initialization

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -186,17 +186,22 @@ chrome.extension.sendMessage({}, function(response) {
     if (blacklisted)
       return;
 
-    var readyStateCheckInterval = setInterval(function() {
-      if (document && document.readyState === 'complete') {
-        clearInterval(readyStateCheckInterval);
+    window.onload = () => initializeNow(document);
+    if (document) {
+      if (document.readyState === "complete") {
         initializeNow(document);
+      } else {
+        document.onreadystatechange = () => {
+          if (document.readyState === "complete") {
+            initializeNow(document);
+          }
+        }
       }
-    }, 10);
+    }
   }
 
   function initializeNow(document) {
-      // in theory, this should only run once, in practice..
-      // that's not guaranteed, hence we enforce own init-once.
+      // enforce init-once due to redundant callers
       if (document.body.classList.contains('vsc-initialized')) {
         return;
       }


### PR DESCRIPTION
Due to an [issue](https://github.com/codebicycle/videospeed/issues/4) with the Firefox fork of this extension I've had a look at this and it would probably be nicer to use the event instead of constantly polling.
This is untested, but literally a copy-paste from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState) so it should work. The [`load`](https://developer.mozilla.org/en-US/docs/Web/Events/load) event would be semantically equivalent.