### PR TITLE
Fixed error when using Chrome Autofill. Closes #250

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -222,7 +222,8 @@ chrome.extension.sendMessage({}, function(response) {
         var keyCode = event.keyCode;
 
         // Ignore if following modifier is active.
-        if (event.getModifierState("Alt")
+        if (!event.getModifierState
+            || event.getModifierState("Alt")
             || event.getModifierState("Control")
             || event.getModifierState("Fn")
             || event.getModifierState("Meta")


### PR DESCRIPTION
This commit fixes the following error when using form autofill:

```
Uncaught TypeError: event.getModifierState is not a function
```
