### PR TITLE
Remove vscid even if ctrl is not found, fixes new Plex web

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -267,9 +267,9 @@ chrome.extension.sendMessage({}, function(response) {
               let id = node.dataset['vscid'];
               let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
               if (ctrl) {
-                node.classList.remove('vsc-initialized');
                 ctrl.remove();
               }
+              node.classList.remove('vsc-initialized');
               delete node.dataset['vscid'];
             }
           }

--- a/inject.js
+++ b/inject.js
@@ -268,9 +268,9 @@ chrome.extension.sendMessage({}, function(response) {
               let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
               if (ctrl) {
                 node.classList.remove('vsc-initialized');
-                delete node.dataset['vscid'];
                 ctrl.remove();
               }
+              delete node.dataset['vscid'];
             }
           }
         } else if (node.children != undefined) {


### PR DESCRIPTION
This fixes an issue with the new Plex web app in which the speed controller will only show up for the first video, but not any after that.

It looks like this happens because when a video finishes, or is exited, its original parent is removed, which removes the wrapper vsc creates.