### PR TITLE
delay DOM node walking via requestIdleCallback

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -279,9 +279,8 @@ chrome.runtime.sendMessage({}, function(response) {
           }
         } else if (node.children != undefined) {
           for (var i = 0; i < node.children.length; i++) {
-            checkForVideo(node.children[i],
-                          node.children[i].parentNode || parent,
-                          added);
+            const child = node.children[i];
+            checkForVideo(child, child.parentNode || parent, added);
           }
         }
       }


### PR DESCRIPTION
I've noticed the `checkForVideo` fn in my profiling lately. For example:

![image](https://user-images.githubusercontent.com/39191/37610828-e88d0e5e-2b5d-11e8-965c-92337ff666ff.png)

Unfortunately by default it's iterating over all added/removed nodes before paint, so we can still be in the critical path of a user gesture.

-------

In this commit, I scheduled the work via `requestIdleCallback`. As a result, the work happens after the paint:

![image](https://user-images.githubusercontent.com/39191/37610911-215cd264-2b5e-11e8-9778-7a285287538a.png)



One caveat: since rIC could delay `checkForVideo` for up to 1 second of idle time, a DOM node could be removed then added back, all before `checkForVideo` has run. However, the mutationObservers will still notify on these changes, so adding/removing the controller will continue happen in the correct sequence. As such, I don't think this is a significant problem, just a timing issue to call out. ;)