### PR TITLE
Fix for #296

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -340,7 +340,7 @@ chrome.runtime.sendMessage({}, function(response) {
         } else if (action === 'slower') {
           // Video min rate is 0.0625:
           // https://cs.chromium.org/chromium/src/third_party/WebKit/Source/core/html/media/HTMLMediaElement.cpp?l=167
-          var s = Math.max(v.playbackRate - tc.settings.speedStep, 0.0625);
+          var s = Math.max(v.playbackRate - tc.settings.speedStep, 0.07);
           v.playbackRate = Number(s.toFixed(2));
         } else if (action === 'reset') {
           resetSpeed(v, 1.0);


### PR DESCRIPTION
new version of chrome gives error when 0.06 speed given.
0.0625.toFixed() gives 0.06 so we should give at least 0.07 to it.