### PR TITLE
Fix for Chrome 71 touch events bug

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -98,11 +98,6 @@ chrome.runtime.sendMessage({}, function(response) {
         top = Math.max(this.video.offsetTop, 0) + "px",
         left = Math.max(this.video.offsetLeft, 0) + "px";
 
-      var prevent = function(e) {
-        e.preventDefault();
-        e.stopPropagation();
-      }
-
       var wrapper = document.createElement('div');
       wrapper.classList.add('vsc-controller');
       wrapper.dataset['vscid'] = this.id;

--- a/inject.js
+++ b/inject.js
@@ -106,9 +106,6 @@ chrome.runtime.sendMessage({}, function(response) {
       var wrapper = document.createElement('div');
       wrapper.classList.add('vsc-controller');
       wrapper.dataset['vscid'] = this.id;
-      wrapper.addEventListener('dblclick', prevent, true);
-      wrapper.addEventListener('mousedown', prevent, true);
-      wrapper.addEventListener('click', prevent, true);
 
       if (tc.settings.startHidden) {
         wrapper.classList.add('vsc-hidden');


### PR DESCRIPTION
Fixes #389, #396, #395, #394, #398 (duplicates)
Also fixes #213 video control panel disappears sometimes after click which was caused by double clicking was canceling. this issue was most commented issue.