### PR TITLE
Add speed controler for audio(basic)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -25,6 +25,7 @@ chrome.runtime.sendMessage({}, function(response) {
 
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false
+      audioBoolean: false, // default: false
       startHidden: false,   // default: false
       keyBindings: [],
       blacklist: `
@@ -90,6 +91,7 @@ chrome.runtime.sendMessage({}, function(response) {
         version: tc.settings.version,
         displayKeyCode: tc.settings.displayKeyCode,
         rememberSpeed: tc.settings.rememberSpeed,
+        audioBoolean: tc.settings.audioBoolean,
         startHidden: tc.settings.startHidden,
         blacklist: tc.settings.blacklist.replace(/^\s+|\s+$/gm, '')
       });
@@ -97,6 +99,7 @@ chrome.runtime.sendMessage({}, function(response) {
     tc.settings.speed = Number(storage.speed);
     tc.settings.displayKeyCode = Number(storage.displayKeyCode);
     tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);
+    tc.settings.audioBoolean = Boolean(storage.audioBoolean);
     tc.settings.startHidden = Boolean(storage.startHidden);
     tc.settings.blacklist = String(storage.blacklist);
 
@@ -214,6 +217,10 @@ chrome.runtime.sendMessage({}, function(response) {
       this.video.classList.add('vsc-initialized');
       this.video.dataset['vscid'] = this.id;
 
+      if(this.video.nodeName === "AUDIO" && tc.settings.audioBoolean)
+        document.body.appendChild(fragment);
+      else
+      {
       switch (true) {
         case (location.hostname == 'www.amazon.com'):
         case (location.hostname == 'www.reddit.com'):
@@ -229,6 +236,7 @@ chrome.runtime.sendMessage({}, function(response) {
           this.parent.insertBefore(fragment, this.parent.firstChild);
       }
     }
+  }
   }
 
   function initializeWhenReady(document) {
@@ -340,7 +348,7 @@ chrome.runtime.sendMessage({}, function(response) {
     var previous_speed = 0;
 
       function checkForVideo(node, parent, added) {
-        if (node.nodeName === 'VIDEO') {
+        if (node.nodeName === 'VIDEO' || node.nodeName === 'AUDIO') {
           if (added) {
             new tc.videoController(node, parent, previous_speed);
           } else {
@@ -384,7 +392,7 @@ chrome.runtime.sendMessage({}, function(response) {
       });
       observer.observe(document, { childList: true, subtree: true });
 
-      var videoTags = document.getElementsByTagName('video');
+      var videoTags = document.querySelectorAll('video,audio');
       forEach.call(videoTags, function(video) {
         new tc.videoController(video);
       });
@@ -398,7 +406,7 @@ chrome.runtime.sendMessage({}, function(response) {
   }
 
   function runAction(action, document, value, e) {
-    var videoTags = document.getElementsByTagName('video');
+    var videoTags = document.querySelectorAll('video,audio');
     videoTags.forEach = Array.prototype.forEach;
 
     videoTags.forEach(function(v) {

--- a/inject.js
+++ b/inject.js
@@ -118,7 +118,7 @@ chrome.runtime.sendMessage({}, function(response) {
   }
 
   function defineVideoController() {
-    tc.videoController = function(target, parent) {
+    tc.videoController = function(target, parent, previous_speed) {
       if (target.dataset['vscid']) {
         return;
       }
@@ -127,7 +127,11 @@ chrome.runtime.sendMessage({}, function(response) {
       this.parent = target.parentElement || parent;
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
-      if (!tc.settings.rememberSpeed) {
+      if (previous_speed) {
+        tc.settings.speed = previous_speed;
+        setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
+      }
+      else if (!tc.settings.rememberSpeed) {
         tc.settings.speed = 1.0;
         setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
       }
@@ -333,12 +337,17 @@ chrome.runtime.sendMessage({}, function(response) {
         }, true);
       });
 
+    var previous_speed = 0;
+
       function checkForVideo(node, parent, added) {
         if (node.nodeName === 'VIDEO') {
           if (added) {
-            new tc.videoController(node, parent);
+            new tc.videoController(node, parent, previous_speed);
           } else {
             if (node.classList.contains('vsc-initialized')) {
+              previous_speed = node.playbackRate;
+              if(previous_speed === 1)
+                previous_speed = 0;
               let id = node.dataset['vscid'];
               let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
               if (ctrl) {

--- a/options.html
+++ b/options.html
@@ -91,6 +91,10 @@
           <input id="rememberSpeed" type="checkbox"/>
       </div>
       <div class="row">
+          <label for="audioBoolean">Work on audios</label>
+          <input id="audioBoolean" type="checkbox"/>
+      </div>
+      <div class="row">
           <label for="blacklist">Blacklisted sites on which extension is disabled<br/>(one per line)</label>
           <textarea id="blacklist" rows="10" cols="50"></textarea>
       </div>

--- a/options.js
+++ b/options.js
@@ -2,6 +2,7 @@ var tcDefaults = {
   speed: 1.0,           // default:
   displayKeyCode: 86,   // default: V
   rememberSpeed: false, // default: false
+  audioBoolean: false, // default: false
   startHidden: false,   // default: false
   keyBindings: [
     {action: "slower", key: 83, value: 0.1, force: false, predefined: true}, // S
@@ -141,6 +142,7 @@ function save_options() {
 
   var displayKeyCode = document.getElementById('displayKeyInput').keyCode;
   var rememberSpeed = document.getElementById('rememberSpeed').checked;
+  var audioBoolean = document.getElementById('audioBoolean').checked;
   var startHidden = document.getElementById('startHidden').checked;
   var blacklist     = document.getElementById('blacklist').value;
 
@@ -150,6 +152,7 @@ function save_options() {
   chrome.storage.sync.set({
     displayKeyCode: displayKeyCode,
     rememberSpeed:  rememberSpeed,
+    audioBoolean:  audioBoolean,
     startHidden:    startHidden,
     keyBindings:    keyBindings,
     blacklist:      blacklist.replace(/^\s+|\s+$/gm,'')
@@ -168,6 +171,7 @@ function restore_options() {
   chrome.storage.sync.get(tcDefaults, function(storage) {
     updateShortcutInputText('displayKeyInput', storage.displayKeyCode);
     document.getElementById('rememberSpeed').checked = storage.rememberSpeed;
+    document.getElementById('audioBoolean').checked = storage.audioBoolean;
     document.getElementById('startHidden').checked = storage.startHidden;
     document.getElementById('blacklist').value = storage.blacklist;
 


### PR DESCRIPTION
there will be a new button in settings page to enable it.
for audio element there will be one button at top of page
it is not working on spotify or soundcould because they are not using audio tags.

I also test it in https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_audio

Note: Run button does not trigger vsc-controller for some reason but it was already bugged in previous versions.