### PR TITLE
fix detecting video on Plex

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -206,7 +206,6 @@
       var fragment = document.createDocumentFragment();
       fragment.appendChild(wrapper);
 
-      this.video.classList.add('vsc-initialized');
       this.video.dataset['vscid'] = this.id;
 
       switch (true) {
@@ -342,13 +341,12 @@
           if (added) {
             new tc.videoController(node, parent);
           } else {
-            if (node.classList.contains('vsc-initialized')) {
-              let id = node.dataset['vscid'];
+            let id = node.dataset['vscid'];
+            if (id) {
               let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
               if (ctrl) {
                 ctrl.remove();
               }
-              node.classList.remove('vsc-initialized');
               delete node.dataset['vscid'];
             }
           }


### PR DESCRIPTION
Fixes https://github.com/igrigorik/videospeed/issues/368
Closes https://github.com/igrigorik/videospeed/pull/403

I added a breakpoint on this line

![screen shot 2019-02-24 at 11 04 01 pm](https://user-images.githubusercontent.com/933490/53313811-22617c80-3889-11e9-9632-2982cf5b0939.png)

Plex removes the `vsc-initialized` class from the video element.

![screen shot 2019-02-24 at 11 04 05 pm](https://user-images.githubusercontent.com/933490/53313813-2392a980-3889-11e9-8f59-ff5a4bce41f7.png)

I figured we don't need to attach that class, since we're labeling video elements with `.dataset` anyway. It's possible that some site will eventually remove all `-data` attributes from a video, and we might be better off attaching the id directly to the node, or a reference to the controller. But until then, this works.

Briefly tested on
- facebook
- netflix
- amazon video