### PR TITLE
Fix issue where youtube resets speed when fullscreen

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -118,6 +118,14 @@
       this.initializeControls();
 
       target.addEventListener('play', function(event) {
+		if (!tc.settings.rememberSpeed) {
+	      if (!tc.settings.speeds[target.src]) {
+			tc.settings.speeds[target.src] = 1.0;
+		  }
+          setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
+        } else{
+		  tc.settings.speeds[target.src]=tc.settings.speed;
+	    }	  
         target.playbackRate = tc.settings.speeds[target.src];
       });
 

--- a/inject.js
+++ b/inject.js
@@ -398,11 +398,17 @@
   function runAction(action, document, value, e) {
     var videoTags = document.getElementsByTagName('video');
     videoTags.forEach = Array.prototype.forEach;
-
+	if (e){
+		var targetController = e.target.getRootNode().host;
+	}
+	
     videoTags.forEach(function(v) {
       var id = v.dataset['vscid'];
+	  
       var controller = document.querySelector(`div[data-vscid="${id}"]`);
-
+	  if (e && !(targetController == controller)) {
+		  return;
+	  }
       showController(controller);
 
       if (!v.classList.contains('vsc-cancelled')) {

--- a/inject.js
+++ b/inject.js
@@ -1,6 +1,7 @@
   var tc = {
     settings: {
       speed: 1.0,           // default 1x
+	  speeds: {},           // empty object to hold speed for each source
 
       /**
        * these are not used and deprecated, will be removed in next update
@@ -21,7 +22,7 @@
        * these(above) are not used and deprecated, will be removed in next update
        * but should be stay there because chrome.storage.sync.get needs them.
        */
-
+ 	  
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
@@ -127,13 +128,17 @@
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
       if (!tc.settings.rememberSpeed) {
-        tc.settings.speed = 1.0;
+		if (!tc.settings.speeds[target.src]) {
+			tc.settings.speeds[target.src] = 1.0;
+		}
         setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
-      }
+      } else{
+		  tc.settings.speeds[target.src]=tc.settings.speed;
+	  }	  
       this.initializeControls();
 
       target.addEventListener('play', function(event) {
-        target.playbackRate = tc.settings.speed;
+        target.playbackRate = tc.settings.speeds[target.src];
       });
 
       target.addEventListener('ratechange', function(event) {
@@ -142,14 +147,14 @@
         if (event.target.readyState > 0) {
           var speed = this.getSpeed();
           this.speedIndicator.textContent = speed;
-          tc.settings.speed = speed;
+          tc.settings.speeds[this.video.src] = speed;
           chrome.storage.sync.set({'speed': speed}, function() {
             console.log('Speed setting saved: ' + speed);
           });
         }
       }.bind(this));
 
-      target.playbackRate = tc.settings.speed;
+      target.playbackRate = tc.settings.speeds[target.src];
     };
 
     tc.videoController.prototype.getSpeed = function() {
@@ -162,7 +167,7 @@
 
     tc.videoController.prototype.initializeControls = function() {
       var document = this.document;
-      var speed = parseFloat(tc.settings.speed).toFixed(2),
+      var speed = parseFloat(tc.settings.speeds[this.video.src]).toFixed(2),
         top = Math.max(this.video.offsetTop, 0) + "px",
         left = Math.max(this.video.offsetLeft, 0) + "px";
 

--- a/inject.js
+++ b/inject.js
@@ -1,7 +1,7 @@
   var tc = {
     settings: {
       speed: 1.0,           // default 1x
-	  speeds: {},           // empty object to hold speed for each source
+      speeds: {},           // empty object to hold speed for each source
  	  
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false
@@ -108,24 +108,24 @@
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
       if (!tc.settings.rememberSpeed) {
-		if (!tc.settings.speeds[target.src]) {
-			tc.settings.speeds[target.src] = 1.0;
-		}
+        if (!tc.settings.speeds[target.src]) {
+          tc.settings.speeds[target.src] = 1.0;
+        }
         setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
       } else{
-		  tc.settings.speeds[target.src]=tc.settings.speed;
-	  }	  
+          tc.settings.speeds[target.src] = tc.settings.speed;
+      }	  
       this.initializeControls();
 
       target.addEventListener('play', function(event) {
-		if (!tc.settings.rememberSpeed) {
-	      if (!tc.settings.speeds[target.src]) {
-			tc.settings.speeds[target.src] = 1.0;
-		  }
+        if (!tc.settings.rememberSpeed) {
+          if (!tc.settings.speeds[target.src]) {
+            tc.settings.speeds[target.src] = 1.0;
+          }
           setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
         } else{
-		  tc.settings.speeds[target.src]=tc.settings.speed;
-	    }	  
+          tc.settings.speeds[target.src] = tc.settings.speed;
+        }	  
         target.playbackRate = tc.settings.speeds[target.src];
       });
 
@@ -386,17 +386,19 @@
   function runAction(action, document, value, e) {
     var videoTags = document.getElementsByTagName('video');
     videoTags.forEach = Array.prototype.forEach;
-	if (e){
-		var targetController = e.target.getRootNode().host;
-	}
+	// Get the controller that was used if called from a button press event e
+    if (e){
+      var targetController = e.target.getRootNode().host;
+    }
 	
     videoTags.forEach(function(v) {
       var id = v.dataset['vscid'];
 	  
       var controller = document.querySelector(`div[data-vscid="${id}"]`);
-	  if (e && !(targetController == controller)) {
-		  return;
-	  }
+	  // Don't change video speed if the video has a different controller
+      if (e && !(targetController == controller)) {
+        return;
+      }
       showController(controller);
 
       if (!v.classList.contains('vsc-cancelled')) {

--- a/inject.js
+++ b/inject.js
@@ -2,8 +2,6 @@
     settings: {
       speed: 1.0,           // default 1x
 
-	  speeds: {},
-	  
       /**
        * these are not used and deprecated, will be removed in next update
        * but should be stay there because chrome.storage.sync.get needs them
@@ -24,7 +22,6 @@
        * but should be stay there because chrome.storage.sync.get needs them.
        */
 
-	  
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
@@ -129,17 +126,14 @@
       this.parent = target.parentElement || parent;
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
-	  var speed=tc.settings.speed;
       if (!tc.settings.rememberSpeed) {
-		if (!tc.settings.speeds[target.src]) {
-			tc.settings.speeds[target.src] = 1.0;
-		}
+        tc.settings.speed = 1.0;
         setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
-      } 
+      }
       this.initializeControls();
 
       target.addEventListener('play', function(event) {
-        target.playbackRate = tc.settings.speeds[target.src];
+        target.playbackRate = tc.settings.speed;
       });
 
       target.addEventListener('ratechange', function(event) {
@@ -148,14 +142,14 @@
         if (event.target.readyState > 0) {
           var speed = this.getSpeed();
           this.speedIndicator.textContent = speed;
-          tc.settings.speeds[this.video.src] = speed;
+          tc.settings.speed = speed;
           chrome.storage.sync.set({'speed': speed}, function() {
             console.log('Speed setting saved: ' + speed);
           });
         }
       }.bind(this));
 
-      target.playbackRate = tc.settings.speeds[target.src];
+      target.playbackRate = tc.settings.speed;
     };
 
     tc.videoController.prototype.getSpeed = function() {
@@ -168,7 +162,7 @@
 
     tc.videoController.prototype.initializeControls = function() {
       var document = this.document;
-      var speed = parseFloat(tc.settings.speeds[this.video.src]).toFixed(2),
+      var speed = parseFloat(tc.settings.speed).toFixed(2),
         top = Math.max(this.video.offsetTop, 0) + "px",
         left = Math.max(this.video.offsetLeft, 0) + "px";
 
@@ -399,17 +393,11 @@
   function runAction(action, document, value, e) {
     var videoTags = document.getElementsByTagName('video');
     videoTags.forEach = Array.prototype.forEach;
-	if (e){
-		var targetController = e.target.getRootNode().host;
-	}
-	
+
     videoTags.forEach(function(v) {
       var id = v.dataset['vscid'];
-	  
       var controller = document.querySelector(`div[data-vscid="${id}"]`);
-	  if (e && !(targetController == controller)) {
-		  return;
-	  }
+
       showController(controller);
 
       if (!v.classList.contains('vsc-cancelled')) {

--- a/inject.js
+++ b/inject.js
@@ -2,6 +2,8 @@
     settings: {
       speed: 1.0,           // default 1x
 
+	  speeds: {},
+	  
       /**
        * these are not used and deprecated, will be removed in next update
        * but should be stay there because chrome.storage.sync.get needs them
@@ -22,6 +24,7 @@
        * but should be stay there because chrome.storage.sync.get needs them.
        */
 
+	  
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false
       startHidden: false,   // default: false
@@ -126,14 +129,17 @@
       this.parent = target.parentElement || parent;
       this.document = target.ownerDocument;
       this.id = Math.random().toString(36).substr(2, 9);
+	  var speed=tc.settings.speed;
       if (!tc.settings.rememberSpeed) {
-        tc.settings.speed = 1.0;
+		if (!tc.settings.speeds[target.src]) {
+			tc.settings.speeds[target.src] = 1.0;
+		}
         setKeyBindings("reset", getKeyBindings("fast")); // resetSpeed = fastSpeed
-      }
+      } 
       this.initializeControls();
 
       target.addEventListener('play', function(event) {
-        target.playbackRate = tc.settings.speed;
+        target.playbackRate = tc.settings.speeds[target.src];
       });
 
       target.addEventListener('ratechange', function(event) {
@@ -142,14 +148,14 @@
         if (event.target.readyState > 0) {
           var speed = this.getSpeed();
           this.speedIndicator.textContent = speed;
-          tc.settings.speed = speed;
+          tc.settings.speeds[this.video.src] = speed;
           chrome.storage.sync.set({'speed': speed}, function() {
             console.log('Speed setting saved: ' + speed);
           });
         }
       }.bind(this));
 
-      target.playbackRate = tc.settings.speed;
+      target.playbackRate = tc.settings.speeds[target.src];
     };
 
     tc.videoController.prototype.getSpeed = function() {
@@ -162,7 +168,7 @@
 
     tc.videoController.prototype.initializeControls = function() {
       var document = this.document;
-      var speed = parseFloat(tc.settings.speed).toFixed(2),
+      var speed = parseFloat(tc.settings.speeds[this.video.src]).toFixed(2),
         top = Math.max(this.video.offsetTop, 0) + "px",
         left = Math.max(this.video.offsetLeft, 0) + "px";
 
@@ -393,11 +399,17 @@
   function runAction(action, document, value, e) {
     var videoTags = document.getElementsByTagName('video');
     videoTags.forEach = Array.prototype.forEach;
-
+	if (e){
+		var targetController = e.target.getRootNode().host;
+	}
+	
     videoTags.forEach(function(v) {
       var id = v.dataset['vscid'];
+	  
       var controller = document.querySelector(`div[data-vscid="${id}"]`);
-
+	  if (e && !(targetController == controller)) {
+		  return;
+	  }
       showController(controller);
 
       if (!v.classList.contains('vsc-cancelled')) {

--- a/inject.js
+++ b/inject.js
@@ -2,26 +2,6 @@
     settings: {
       speed: 1.0,           // default 1x
 	  speeds: {},           // empty object to hold speed for each source
-
-      /**
-       * these are not used and deprecated, will be removed in next update
-       * but should be stay there because chrome.storage.sync.get needs them
-       */
-      resetSpeed: 1.0,      // default 1.0
-      speedStep: null,       // default 0.1x just for buttons
-      fastSpeed: null,       // default 1.8x
-      rewindTime: null,       // default 10s just for buttons
-      advanceTime: null,      // default 10s just for buttons
-      resetKeyCode: null,    // default: R
-      slowerKeyCode: null,    // default: S
-      fasterKeyCode: null,    // default: D
-      rewindKeyCode: null,    // default: Z
-      advanceKeyCode: null,   // default: X
-      fastKeyCode: null,      // default: G
-      /**
-       * these(above) are not used and deprecated, will be removed in next update
-       * but should be stay there because chrome.storage.sync.get needs them.
-       */
  	  
       displayKeyCode: 86,   // default: V
       rememberSpeed: false, // default: false


### PR DESCRIPTION
Fixes #370

Track the speed of a video based on its source at time of last
ratechange. Newly initialize video controller with same speed as
other controllers of video with same source automatically.

Allow different speeds for different sources in same frame. Make a
controller button press only affect that controller.

Remove the deprecated settings.

