### PR TITLE
Hide controller for videos with no source

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -1,8 +1,10 @@
+.vsc-nosource { display: none !important; }
 .vsc-hidden { display: none !important; }
 .vsc-manual {
   visibility: visible !important;
   opacity: 1.0 !important;
 }
+
 
 /* Origin specific overrides */
 /* YouTube player */

--- a/inject.css
+++ b/inject.css
@@ -5,7 +5,6 @@
   opacity: 1.0 !important;
 }
 
-
 /* Origin specific overrides */
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {

--- a/inject.js
+++ b/inject.js
@@ -154,7 +154,7 @@
         }
       }.bind(this));
 
-      var observer=new MutationObserver((mutations)=> {
+      var observer=new MutationObserver((mutations) => {
         mutations.forEach((mutation) => {
           if (mutation.type === 'attributes' && mutation.attributeName === 'src'){
             var controller = document.querySelector(`div[data-vscid="${this.id}"]`);
@@ -163,10 +163,8 @@
             }
             if (!mutation.target.src) {
               controller.classList.add('vsc-nosource');
-              console.log('Hiding: no source');
             } else {
               controller.classList.remove('vsc-nosource');
-              console.log('showing: '+mutation.target.src);
             }
           }
         });

--- a/inject.js
+++ b/inject.js
@@ -165,7 +165,7 @@
               controller.classList.add('vsc-nosource');
               console.log('Hiding: no source');
             } else {
-              ontroller.classList.remove('vsc-nosource');
+              controller.classList.remove('vsc-nosource');
               console.log('showing: '+mutation.target.src);
             }
           }
@@ -193,6 +193,10 @@
       var wrapper = document.createElement('div');
       wrapper.classList.add('vsc-controller');
       wrapper.dataset['vscid'] = this.id;
+
+      if (!this.video.src) {
+        wrapper.classList.add('vsc-nosource');
+      }
 
       if (tc.settings.startHidden) {
         wrapper.classList.add('vsc-hidden');

--- a/inject.js
+++ b/inject.js
@@ -123,9 +123,11 @@
       } else {
         tc.settings.speeds[target.src] = tc.settings.lastSpeed;
       }
+      target.playbackRate = tc.settings.speeds[target.src];
+
       this.initializeControls();
 
-      target.addEventListener('play', function(event) {
+	  target.addEventListener('play', function(event) {
         if (!tc.settings.rememberSpeed) {
           if (!tc.settings.speeds[target.src]) {
             tc.settings.speeds[target.src] = this.speed;
@@ -152,7 +154,26 @@
         }
       }.bind(this));
 
-      target.playbackRate = tc.settings.speeds[target.src];
+      var observer=new MutationObserver((mutations)=> {
+        mutations.forEach((mutation) => {
+          if (mutation.type === 'attributes' && mutation.attributeName === 'src'){
+            var controller = document.querySelector(`div[data-vscid="${this.id}"]`);
+            if(!controller){
+              return;
+            }
+            if (!mutation.target.src) {
+              controller.classList.add('vsc-nosource');
+              console.log('Hiding: no source');
+            } else {
+              ontroller.classList.remove('vsc-nosource');
+              console.log('showing: '+mutation.target.src);
+            }
+          }
+        });
+      });
+      observer.observe(target, {
+        attributeFilter: ["src"]
+      });
     };
 
     tc.videoController.prototype.getSpeed = function() {

--- a/inject.js
+++ b/inject.js
@@ -127,7 +127,7 @@
 
       this.initializeControls();
 
-	  target.addEventListener('play', function(event) {
+      target.addEventListener('play', function(event) {
         if (!tc.settings.rememberSpeed) {
           if (!tc.settings.speeds[target.src]) {
             tc.settings.speeds[target.src] = this.speed;


### PR DESCRIPTION
Fixes #236 

Creates a mutation observer that will detect when source changes. Hides visible controller when there is no source present. Prevents double/more controllers being visible.