### PR TITLE
Fully remove videoController on video removal

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -346,7 +346,8 @@
 
 
       function checkForVideo(node, parent, added) {
-        if (document.body.contains(node)) {
+        // Only proceed with supposed removal if node is missing from DOM
+        if (!added && document.body.contains(node)) {
           return;
         }
         if (node.nodeName === 'VIDEO' || (node.nodeName === 'AUDIO' && tc.settings.audioBoolean)) {

--- a/inject.js
+++ b/inject.js
@@ -346,15 +346,15 @@
 
 
       function checkForVideo(node, parent, added) {
+        if (document.body.contains(node)) {
+          return;
+        }
         if (node.nodeName === 'VIDEO' || (node.nodeName === 'AUDIO' && tc.settings.audioBoolean)) {
           if (added) {
             node.vsc = new tc.videoController(node, parent);
           } else {
             let id = node.dataset['vscid'];
             if (id) {
-              if (document.body.contains(node)) {
-                return;
-              }
               node.vsc.remove();
             }
           }

--- a/inject.js
+++ b/inject.js
@@ -348,6 +348,9 @@
             let id = node.dataset['vscid'];
             if (id) {
               let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
+              if (document.body.contains(node)) {
+                return;
+              }
               if (ctrl) {
                 ctrl.remove();
               }

--- a/inject.js
+++ b/inject.js
@@ -103,7 +103,7 @@
   function defineVideoController() {
     tc.videoController = function(target, parent) {
       if (target.dataset['vscid']) {
-        return;
+        return target.vsc;
       }
 
       this.video = target;
@@ -123,9 +123,9 @@
       } else {
         tc.settings.speeds[target.src] = tc.settings.lastSpeed;
       }
-      this.initializeControls();
+      this.div = this.initializeControls();
 
-      target.addEventListener('play', function(event) {
+      target.addEventListener('play', this.handlePlay = function(event) {
         if (!tc.settings.rememberSpeed) {
           if (!tc.settings.speeds[target.src]) {
             tc.settings.speeds[target.src] = this.speed;
@@ -137,7 +137,7 @@
         target.playbackRate = tc.settings.speeds[target.src];
       }.bind(this));
 
-      target.addEventListener('ratechange', function(event) {
+      target.addEventListener('ratechange', this.handleRatechange = function(event) {
         // Ignore ratechange events on unitialized videos.
         // 0 == No information is available about the media resource.
         if (event.target.readyState > 0) {
@@ -160,7 +160,11 @@
     }
 
     tc.videoController.prototype.remove = function() {
-      this.parentElement.removeChild(this);
+      this.div.remove();
+      this.video.removeEventListener('play',this.handlePlay);
+      this.video.removeEventListener('ratechange',this.handleRatechange);
+      delete this.video.dataset['vscid'];
+      delete this.video.vsc;
     }
 
     tc.videoController.prototype.initializeControls = function() {
@@ -225,6 +229,7 @@
           // the first element of the target, which may not be the parent.
           this.parent.insertBefore(fragment, this.parent.firstChild);
       }
+	  return wrapper;
     }
   }
 
@@ -343,18 +348,14 @@
       function checkForVideo(node, parent, added) {
         if (node.nodeName === 'VIDEO' || (node.nodeName === 'AUDIO' && tc.settings.audioBoolean)) {
           if (added) {
-            new tc.videoController(node, parent);
+            node.vsc = new tc.videoController(node, parent);
           } else {
             let id = node.dataset['vscid'];
             if (id) {
-              let ctrl = document.querySelector(`div[data-vscid="${id}"]`)
               if (document.body.contains(node)) {
                 return;
               }
-              if (ctrl) {
-                ctrl.remove();
-              }
-              delete node.dataset['vscid'];
+              node.vsc.remove();
             }
           }
         } else if (node.children != undefined) {
@@ -391,7 +392,7 @@
       }
 	  
       forEach.call(mediaTags, function(video) {
-        new tc.videoController(video);
+        video.vsc = new tc.videoController(video);
       });
 
       var frameTags = document.getElementsByTagName('iframe');


### PR DESCRIPTION
Fixes #468 

Often times video tags that are detected as "removed" are never actually removed. Even if they are, they may be placed back in the DOM later. In master either of these will result in multiple eventListeners and videoController js objects for that video. This PR prevents that by removing the eventListeners and giving videos a reference to their videoController object.

It also increases efficiency by checking that removed objects are not present in the DOM before recursively checking for removed videos. According to devtools this accounts for ~half of time VSC currently uses on youtube loads.