### PR TITLE
Add feature to jump to marker

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -484,6 +484,10 @@
           pauseSpeed(v, value);
         } else if (action === 'muted') {
           muted(v, value);
+        } else if (action === 'mark') {
+          setMark(v);
+        } else if (action === 'jump') {
+          jumpToMark(v);
         }
       }
     });
@@ -518,6 +522,16 @@
     v.muted = v.muted !== true;
   }
 
+  function setMark(v) {
+    v.vsc.mark = v.currentTime;
+  }
+  
+  function jumpToMark(v) {
+    if (v.vsc.mark && typeof v.vsc.mark === "number") {
+      v.currentTime = v.vsc.mark;
+    }
+  }
+  
   function handleDrag(video, controller, e) {
     const shadowController = controller.shadowRoot.querySelector('#controller');
 

--- a/options.css
+++ b/options.css
@@ -101,3 +101,8 @@ select {
 .customForce {
 	display: none;
 }
+
+.customKey {
+  color: transparent;
+  text-shadow: 0 0 0 #000000;
+}

--- a/options.js
+++ b/options.js
@@ -100,6 +100,8 @@ function updateCustomShortcutInputText(inputItem, keyCode) {
   inputItem.keyCode = keyCode;
 }
 
+var customActionsNoValues=["pause","mute","mark","jump"];
+
 function add_shortcut() {
   var html = `<select class="customDo">
     <option value="slower">Decrease speed</option>
@@ -195,7 +197,7 @@ function restore_options() {
         const dom = document.querySelector(".customs:last-of-type")
         dom.querySelector(".customDo").value = item["action"];
 
-        if (item["action"] === "pause" || item["action"] === "muted" || item["action"] === "mark" || item["action"] === "jump")
+        if (customActionsNoValues.includes(item["action"]))
           dom.querySelector(".customValue").disabled = true;
 
         updateCustomShortcutInputText(dom.querySelector(".customKey"), item["key"]);
@@ -265,16 +267,11 @@ document.addEventListener('DOMContentLoaded', function () {
   });
   document.addEventListener('change', (event) => {
     eventCaller(event, "customDo", function () {
-      switch (event.target.value) {
-        case "muted":
-        case "pause":
-        case "mark":
-        case "jump":
-          event.target.nextElementSibling.nextElementSibling.disabled = true;
-          event.target.nextElementSibling.nextElementSibling.value = 0;
-          break;
-        default:
-          event.target.nextElementSibling.nextElementSibling.disabled = false;
+      if (customActionsNoValues.includes(event.target.value)) {
+        event.target.nextElementSibling.nextElementSibling.disabled = true;
+        event.target.nextElementSibling.nextElementSibling.value = 0;
+      } else {
+        event.target.nextElementSibling.nextElementSibling.disabled = false;
       }
     })
   });

--- a/options.js
+++ b/options.js
@@ -100,7 +100,7 @@ function updateCustomShortcutInputText(inputItem, keyCode) {
   inputItem.keyCode = keyCode;
 }
 
-var customActionsNoValues=["pause","mute","mark","jump"];
+var customActionsNoValues=["pause","muted","mark","jump"];
 
 function add_shortcut() {
   var html = `<select class="customDo">

--- a/options.js
+++ b/options.js
@@ -110,6 +110,8 @@ function add_shortcut() {
     <option value="fast">Preferred speed</option>
     <option value="muted">Mute</option>
     <option value="pause">Pause</option>
+    <option value="mark">Set marker</option>
+    <option value="jump">Jump to marker</option>
     </select> 
     <input class="customKey" type="text" placeholder="press a key"/> 
     <input class="customValue" type="text" placeholder="value (0.10)"/> 
@@ -123,6 +125,9 @@ function add_shortcut() {
   div.innerHTML = html;
   var customs_element = document.getElementById("customs");
   customs_element.insertBefore(div, customs_element.children[customs_element.childElementCount - 1]);
+  div.querySelector("select").oninput = (e) => {
+    e.target.nextElementSibling.focus();
+  };
 }
 
 function createKeyBindings(item) {
@@ -190,7 +195,7 @@ function restore_options() {
         const dom = document.querySelector(".customs:last-of-type")
         dom.querySelector(".customDo").value = item["action"];
 
-        if (item["action"] === "pause" || item["action"] === "muted")
+        if (item["action"] === "pause" || item["action"] === "muted" || item["action"] === "mark" || item["action"] === "jump")
           dom.querySelector(".customValue").disabled = true;
 
         updateCustomShortcutInputText(dom.querySelector(".customKey"), item["key"]);
@@ -263,6 +268,8 @@ document.addEventListener('DOMContentLoaded', function () {
       switch (event.target.value) {
         case "muted":
         case "pause":
+        case "mark":
+        case "jump":
           event.target.nextElementSibling.nextElementSibling.disabled = true;
           event.target.nextElementSibling.nextElementSibling.value = 0;
           break;

--- a/options.js
+++ b/options.js
@@ -127,9 +127,6 @@ function add_shortcut() {
   div.innerHTML = html;
   var customs_element = document.getElementById("customs");
   customs_element.insertBefore(div, customs_element.children[customs_element.childElementCount - 1]);
-  div.querySelector("select").oninput = (e) => {
-    e.target.nextElementSibling.focus();
-  };
 }
 
 function createKeyBindings(item) {

--- a/options.js
+++ b/options.js
@@ -100,6 +100,7 @@ function updateCustomShortcutInputText(inputItem, keyCode) {
   inputItem.keyCode = keyCode;
 }
 
+// List of custom actions for which customValue should be disabled
 var customActionsNoValues=["pause","muted","mark","jump"];
 
 function add_shortcut() {


### PR DESCRIPTION
Closes #470 

Adds two options for new custom hotkeys. One to set a marker and another to jump to a marker.

Also refactors logic so that list of actions with no value only needs to be specified once.

