### PR TITLE
Add teams.microsoft.com to default blacklist

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -16,6 +16,7 @@
         twitter.com
         vine.co
         imgur.com
+        teams.microsoft.com
       `.replace(regStrip,'')
     }
   };

--- a/options.js
+++ b/options.js
@@ -20,6 +20,7 @@ var tcDefaults = {
     twitter.com
     vine.co
     imgur.com
+    teams.microsoft.com
   `.replace(regStrip, '')
 };
 


### PR DESCRIPTION
Microsoft Teams is used for video conferencing, and this extension
causes all of the videos to be half cut off. I think it would be a good
idea to add it to the default blacklist.