### PR TITLE
Add ability to disable website keybindings for show/hide controller (Fixes: #526)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -6,7 +6,6 @@
       speeds: {},           // empty object to hold speed for each source
 
       displayKeyCode: 86,   // default: V
-      displayForce: false,
       rememberSpeed: false, // default: false
       audioBoolean: false,  // default: false
       startHidden: false,   // default: false
@@ -75,7 +74,6 @@
         keyBindings: tc.settings.keyBindings,
         version: tc.settings.version,
         displayKeyCode: tc.settings.displayKeyCode,
-        displayForce: tc.settings.displayForce,
         rememberSpeed: tc.settings.rememberSpeed,
         audioBoolean: tc.settings.audioBoolean,
         startHidden: tc.settings.startHidden,
@@ -85,12 +83,22 @@
     }
     tc.settings.lastSpeed = Number(storage.lastSpeed);
     tc.settings.displayKeyCode = Number(storage.displayKeyCode);
-    tc.settings.displayForce = String(storage.displayForce);
     tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);
     tc.settings.audioBoolean = Boolean(storage.audioBoolean);
     tc.settings.startHidden = Boolean(storage.startHidden);
     tc.settings.controllerOpacity = Number(storage.controllerOpacity);
     tc.settings.blacklist = String(storage.blacklist);
+
+    // ensure that there is a "display" binding (for upgrades from versions that had it as a separate binding)
+    if (tc.settings.keyBindings.filter(x => x.action == "display").length == 0) {
+      tc.settings.keyBindings.push({
+        action: "display",
+        key: Number(storage.displayKeyCode) || 86,
+        value: 0,
+        force: false,
+        predefined: true
+      }); // default V
+    }
 
     initializeWhenReady(document);
   });
@@ -361,13 +369,6 @@
             return false;
           }
 
-          if (keyCode == tc.settings.displayKeyCode) {
-            runAction('display', document, true)
-            if (tc.settings.displayForce === "true") {// disable websites key bindings
-              event.preventDefault();
-              event.stopPropagation();
-            }
-          }
         var item = tc.settings.keyBindings.find(item => item.key === keyCode);
         if (item) {
           runAction(item.action, document, item.value);

--- a/inject.js
+++ b/inject.js
@@ -6,6 +6,7 @@
       speeds: {},           // empty object to hold speed for each source
 
       displayKeyCode: 86,   // default: V
+      displayForce: false,
       rememberSpeed: false, // default: false
       audioBoolean: false,  // default: false
       startHidden: false,   // default: false
@@ -74,6 +75,7 @@
         keyBindings: tc.settings.keyBindings,
         version: tc.settings.version,
         displayKeyCode: tc.settings.displayKeyCode,
+        displayForce: tc.settings.displayForce,
         rememberSpeed: tc.settings.rememberSpeed,
         audioBoolean: tc.settings.audioBoolean,
         startHidden: tc.settings.startHidden,
@@ -83,6 +85,7 @@
     }
     tc.settings.lastSpeed = Number(storage.lastSpeed);
     tc.settings.displayKeyCode = Number(storage.displayKeyCode);
+    tc.settings.displayForce = String(storage.displayForce);
     tc.settings.rememberSpeed = Boolean(storage.rememberSpeed);
     tc.settings.audioBoolean = Boolean(storage.audioBoolean);
     tc.settings.startHidden = Boolean(storage.startHidden);
@@ -360,6 +363,10 @@
 
           if (keyCode == tc.settings.displayKeyCode) {
             runAction('display', document, true)
+            if (tc.settings.displayForce === "true") {// disable websites key bindings
+              event.preventDefault();
+              event.stopPropagation();
+            }
           }
         var item = tc.settings.keyBindings.find(item => item.key === keyCode);
         if (item) {

--- a/options.html
+++ b/options.html
@@ -15,6 +15,10 @@
       <div class="row">
         <label for="displayKeyInput">Show/hide controller</label>
         <input id="displayKeyInput" placeholder="press a key" type="text" value=""/>
+        <select class="customForce" id="displayForce">
+            <option value="false">Do not disable website key bindings</option>
+            <option value="true">Disable websites key bindings</option>
+        </select>
       </div>
         <div class="row customs" id="slower">
             <select class="customDo">

--- a/options.html
+++ b/options.html
@@ -12,14 +12,16 @@
 
     <section id="customs">
       <h3>Shortcuts</h3>
-      <div class="row">
-        <label for="displayKeyInput">Show/hide controller</label>
-        <input id="displayKeyInput" placeholder="press a key" type="text" value=""/>
-        <select class="customForce" id="displayForce">
-            <option value="false">Do not disable website key bindings</option>
-            <option value="true">Disable websites key bindings</option>
-        </select>
-      </div>
+        <div class="row customs" id="display">
+            <select class="customDo">
+                <option value="display">Show/hide controller</option>
+            </select>
+            <input class="customKey" type="text" value="" placeholder="press a key">
+            <input class="customValue" type="text" placeholder="value (0.10)">
+            <select class="customForce">
+                <option value="false">Do not disable website key bindings</option>
+                <option value="true">Disable websites key bindings</option>
+            </select></div>
         <div class="row customs" id="slower">
             <select class="customDo">
                 <option value="slower">Decrease speed</option>

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ var regStrip=/^[\r\t\f\v ]+|[\r\t\f\v ]+$/gm;
 var tcDefaults = {
   speed: 1.0,           // default:
   displayKeyCode: 86,   // default: V
+  displayForce: false,
   rememberSpeed: false, // default: false
   audioBoolean: false, // default: false
   startHidden: false,   // default: false
@@ -150,6 +151,7 @@ function save_options() {
   Array.from(document.querySelectorAll(".customs")).forEach(item => createKeyBindings(item)); // Remove added shortcuts
 
   var displayKeyCode = document.getElementById('displayKeyInput').keyCode;
+  var displayForce = document.getElementById('displayForce').value;
   var rememberSpeed = document.getElementById('rememberSpeed').checked;
   var audioBoolean = document.getElementById('audioBoolean').checked;
   var startHidden = document.getElementById('startHidden').checked;
@@ -161,6 +163,7 @@ function save_options() {
   chrome.storage.sync.remove(["resetSpeed", "speedStep", "fastSpeed", "rewindTime", "advanceTime", "resetKeyCode", "slowerKeyCode", "fasterKeyCode", "rewindKeyCode", "advanceKeyCode", "fastKeyCode"]);
   chrome.storage.sync.set({
     displayKeyCode: displayKeyCode,
+    displayForce: displayForce,
     rememberSpeed:  rememberSpeed,
     audioBoolean:  audioBoolean,
     startHidden:    startHidden,
@@ -181,6 +184,7 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get(tcDefaults, function(storage) {
     updateShortcutInputText('displayKeyInput', storage.displayKeyCode);
+    document.getElementById('displayForce').value = storage.displayForce;
     document.getElementById('rememberSpeed').checked = storage.rememberSpeed;
     document.getElementById('audioBoolean').checked = storage.audioBoolean;
     document.getElementById('startHidden').checked = storage.startHidden;


### PR DESCRIPTION
- Adding the select dropdown to allow disabling website keybinds for the "Show/hide controller" option similar to the other keybindings
- it only shows when clicking "show experimental features"
![image](https://user-images.githubusercontent.com/892961/66641220-e549cf00-ec4c-11e9-8b51-f30806e974c7.png)

**Demo**
Demo of it showing only after clicking "show experimental features" and of it being able to persist on saving
![show-hide](https://user-images.githubusercontent.com/892961/66641314-0f9b8c80-ec4d-11e9-8b04-57a2ba26523c.gif)

