### PR TITLE
Adding feature - Show the controller briefly when adjusting speed and the controller is set to hidden.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -172,6 +172,7 @@
           chrome.storage.sync.set({'lastSpeed': speed}, function() {
             console.log('Speed setting saved: ' + speed);
           });
+          // show the controller for 1000ms if it's hidden.
           runAction('blink', document, 1000, null);
         }
       }.bind(this));
@@ -496,6 +497,7 @@
           controller.classList.add('vsc-manual');
           controller.classList.toggle('vsc-hidden');
         } else if (action === 'blink') {
+            // if vsc is hidden, show it briefly to give the use visual feedback that the action is excuted.
             if(controller.classList.contains('vsc-hidden') || controller.blinkTimeOut !== undefined){
               clearTimeout(controller.blinkTimeOut);
               controller.classList.remove('vsc-hidden');

--- a/inject.js
+++ b/inject.js
@@ -173,7 +173,7 @@
             console.log('Speed setting saved: ' + speed);
           });
           // show the controller for 1000ms if it's hidden.
-          runAction('blink', document, 1000, null);
+          runAction('blink', document, null, null);
         }
       }.bind(this));
 
@@ -504,7 +504,7 @@
               controller.blinkTimeOut = setTimeout(()=>{
                 controller.classList.add('vsc-hidden');
                 controller.blinkTimeOut = undefined;
-              }, value);
+              }, value ? value : 1000);
             }
         } else if (action === 'drag') {
           handleDrag(v, controller, e);

--- a/inject.js
+++ b/inject.js
@@ -172,6 +172,7 @@
           chrome.storage.sync.set({'lastSpeed': speed}, function() {
             console.log('Speed setting saved: ' + speed);
           });
+          runAction('blink', document, 1000, null);
         }
       }.bind(this));
 
@@ -494,6 +495,15 @@
         } else if (action === 'display') {
           controller.classList.add('vsc-manual');
           controller.classList.toggle('vsc-hidden');
+        } else if (action === 'blink') {
+            if(controller.classList.contains('vsc-hidden') || controller.blinkTimeOut !== undefined){
+              clearTimeout(controller.blinkTimeOut);
+              controller.classList.remove('vsc-hidden');
+              controller.blinkTimeOut = setTimeout(()=>{
+                controller.classList.add('vsc-hidden');
+                controller.blinkTimeOut = undefined;
+              }, value);
+            }
         } else if (action === 'drag') {
           handleDrag(v, controller, e);
         } else if (action === 'fast') {


### PR DESCRIPTION
Hey, community,

As a loyal user of this extension, I love it so much and use it thousands of times every day.

I like to hide the controller to have a clear view of the screen. However, when I adjust the video speed, I feel anxious because I can't see the current speed since the controller is hidden. 

I don't like this uncertainty, so I added a small feature to this extension, and hope you guys like it.

When the rate changes and the controller is set to hidden, the controller will show up briefly to give the user clear feedback, and then disappear again. 

To do this, I added a new action called `blink` and call `runAction('blink')` in the event `'ratechange'`.

![vs](https://user-images.githubusercontent.com/9332910/67903302-930c1780-fb41-11e9-9aed-e4b2c9c3c28b.gif)

In this demo, the controller is hidden by default and I only pressed `d` and `s` several times.

The default duration is set to 1000 ms, but you can adjust it by passing `value` into `runAction()`, in case we want to make it customizable in the future.

Please let me know your thoughts, comments or feedback. 

That's it, thank you guys!
