### PR TITLE
Prevent disabling default keybindings from disabling text input.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -364,9 +364,9 @@
           }
 
           // Ignore keydown event if typing in an input box
-          if (document.activeElement.nodeName === 'INPUT'
-              || document.activeElement.nodeName === 'TEXTAREA'
-              || document.activeElement.isContentEditable) {
+          if (event.target.nodeName === 'INPUT'
+              || event.target.nodeName === 'TEXTAREA'
+              || event.target.isContentEditable) {
             return false;
           }
 


### PR DESCRIPTION
Fixes #543 

The check for text input was previously done on document.activeElement. However because VSC is running in multiple contexts (and events are passed to parent contexts since #334) the activeElement in some contexts is the body. 

This changes it to look at the event.target for text editability instead.

Test driving now for unexpected issues. Let me know what y'all think.