### PR TITLE
Reset position of vsc with hotkey

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -69,6 +69,14 @@
         force: false,
         predefined: true
       }); // default: G
+      tc.settings.keyBindings.push({
+        action: "reposition",
+        key: Number(storage.repositionKeyCode) || 72,
+        value: 0,
+        force: false,
+        predefined: true
+      }); // default: H
+
       tc.settings.version = "0.5.3";
 
       chrome.storage.sync.set({
@@ -444,7 +452,7 @@
       } else {
         var mediaTags = document.querySelectorAll('video');
       }
-	  
+
       forEach.call(mediaTags, function(video) {
         video.vsc = new tc.videoController(video);
       });
@@ -469,13 +477,13 @@
     // Get the controller that was used if called from a button press event e
     if (e) {
       var targetController = e.target.getRootNode().host;
-    } 
+    }
 
     mediaTags.forEach(function(v) {
       var id = v.dataset['vscid'];
       var controller = document.querySelector(`div[data-vscid="${id}"]`);
 
-      // Don't change video speed if the video has a different controller	
+      // Don't change video speed if the video has a different controller
       if (e && !(targetController == controller)) {
         return;
       }
@@ -527,6 +535,8 @@
           setMark(v);
         } else if (action === 'jump') {
           jumpToMark(v);
+        } else if (action === 'reposition') {
+          handleReposition(v, controller);
         }
       }
     });
@@ -564,13 +574,13 @@
   function setMark(v) {
     v.vsc.mark = v.currentTime;
   }
-  
+
   function jumpToMark(v) {
     if (v.vsc.mark && typeof v.vsc.mark === "number") {
       v.currentTime = v.vsc.mark;
     }
   }
-  
+
   function handleDrag(video, controller, e) {
     const shadowController = controller.shadowRoot.querySelector('#controller');
 
@@ -611,6 +621,21 @@
     parentElement.addEventListener('mouseup',stopDragging);
     parentElement.addEventListener('mouseleave',stopDragging);
     parentElement.addEventListener('mousemove', startDragging);
+  }
+
+  function handleReposition(video, controller) { // 481_NEW: handling reposition
+    const shadowController = controller.shadowRoot.querySelector('#controller');
+    // Find nearest parent of same size as video parent.
+    var parentElement = controller.parentElement;
+    while (parentElement.parentNode &&
+      parentElement.parentNode.offsetHeight === parentElement.offsetHeight &&
+      parentElement.parentNode.offsetWidth === parentElement.offsetWidth) {
+      parentElement = parentElement.parentNode;
+    }
+
+    let style = shadowController.style;
+    style.left = Math.max(video.offsetLeft, 0) + "px";
+    style.top  = Math.max(video.offsetTop, 0) + "px";
   }
 
   var timer;

--- a/options.html
+++ b/options.html
@@ -82,6 +82,16 @@
                 <option value="false">Do not disable website key bindings</option>
                 <option value="true">Disable websites key bindings</option>
             </select></div>
+        <div class="row customs" id="reposition">
+            <select class="customDo">
+                <option value="reposition">Reset controller position</option>
+            </select>
+            <input class="customKey" type="text" value="" placeholder="press a key">
+            <input class="customValue" type="text" placeholder="value (0.10)">
+            <select class="customForce">
+                <option value="false">Do not disable website key bindings</option>
+                <option value="true">Disable websites key bindings</option>
+            </select></div>
 
         <button id="add">Add New</button>
     </section>

--- a/options.js
+++ b/options.js
@@ -15,7 +15,8 @@ var tcDefaults = {
     {action: "rewind", key: 90, value: 10, force: false, predefined: true}, // Z
     {action: "advance", key: 88, value: 10, force: false, predefined: true}, // X
     {action: "reset", key: 82, value: 1, force: false, predefined: true}, // R
-    {action: "fast", key: 71, value: 1.8, force: false, predefined: true} // G
+    {action: "fast", key: 71, value: 1.8, force: false, predefined: true}, // G
+    {action: "reposition", key: 72, value: 0, force: false, predefined: true} // H
   ],
   blacklist: `
     www.instagram.com
@@ -123,7 +124,7 @@ function updateCustomShortcutInputText(inputItem, keyCode) {
 }
 
 // List of custom actions for which customValue should be disabled
-var customActionsNoValues=["pause","muted","mark","jump","display"];
+var customActionsNoValues=["pause","muted","mark","jump","display","reposition"];
 
 function add_shortcut() {
   var html = `<select class="customDo">
@@ -138,9 +139,10 @@ function add_shortcut() {
     <option value="mark">Set marker</option>
     <option value="jump">Jump to marker</option>
     <option value="display">Show/hide controller</option>
-    </select> 
-    <input class="customKey" type="text" placeholder="press a key"/> 
-    <input class="customValue" type="text" placeholder="value (0.10)"/> 
+    <option value="reposition">Reset controller position</option>
+    </select>
+    <input class="customKey" type="text" placeholder="press a key"/>
+    <input class="customValue" type="text" placeholder="value (0.10)"/>
     <select class="customForce">
     <option value="false">Do not disable website key bindings</option>
     <option value="true">Disable websites key bindings</option>
@@ -198,7 +200,7 @@ function save_options() {
   var controllerOpacity = document.getElementById('controllerOpacity').value;
   var blacklist     = document.getElementById('blacklist').value;
 
-  chrome.storage.sync.remove(["resetSpeed", "speedStep", "fastSpeed", "rewindTime", "advanceTime", "resetKeyCode", "slowerKeyCode", "fasterKeyCode", "rewindKeyCode", "advanceKeyCode", "fastKeyCode"]);
+  chrome.storage.sync.remove(["resetSpeed", "speedStep", "fastSpeed", "rewindTime", "advanceTime", "resetKeyCode", "slowerKeyCode", "fasterKeyCode", "rewindKeyCode", "advanceKeyCode", "fastKeyCode", "repositionKeyCode"]);
   chrome.storage.sync.set({
     rememberSpeed:  rememberSpeed,
     audioBoolean:  audioBoolean,


### PR DESCRIPTION
Added a hot key ("H" for "home") to move the video speed controller back to the upper left corner to avoid losing the controller due to varying video resizings, or for when it gets stuck