### PR TITLE
Add width styling to .customForce class.

### DIFF
--- a/options.css
+++ b/options.css
@@ -100,6 +100,7 @@ select {
 
 .customForce {
 	display: none;
+	width: 250px;
 }
 
 .customKey {


### PR DESCRIPTION
Currently, the width of the customForce class is too narrow to display the full text of the experimental options ("Do not disable website keybindings.", "Disables websites keybindings").  250px might be too wide still but it seems like a good start.

Before:
![screenshot12-20-19_18-28-42](https://user-images.githubusercontent.com/405531/71298537-9a3bee80-2356-11ea-923c-5e5d4a737b04.png)

After:
![screenshot12-20-19_18-24-32](https://user-images.githubusercontent.com/405531/71298434-05d18c00-2356-11ea-9466-799635a12553.png)
