### PR TITLE
Fix VSC not showing

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -184,7 +184,7 @@
             if(!controller){
               return;
             }
-            if (!mutation.target.currentSrc) {
+            if (!mutation.target.src && !mutation.target.currentSrc) {
               controller.classList.add('vsc-nosource');
             } else {
               controller.classList.remove('vsc-nosource');


### PR DESCRIPTION
Fixes: #566 

The problem was introduced in https://github.com/igrigorik/videospeed/pull/529 in this line https://github.com/igrigorik/videospeed/pull/529/files#diff-e24e9eb38cffaafae22019e36f31a570R171

In testing it looks like the mutation observer can have a blank `currentSrc` but `src` is specified, so changing current code to look for both attributes and only add `vsc-nosource` if both are not found 

![image](https://user-images.githubusercontent.com/892961/71468959-a4e8fe80-2802-11ea-8bad-ad90b42a6874.png)

To get extra logging shown above just apply [this patch](https://github.com/igrigorik/videospeed/files/4002036/patch.txt) to current master via `git apply patch.txt`



