### PR TITLE
Added ratechange cooldown to fix #72 #521 and #584

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ local
 
 # IntelliJ IDEA
 .idea/
+node_modules

--- a/inject.js
+++ b/inject.js
@@ -374,11 +374,7 @@ function refreshCoolDown() {
   log("End refreshCoolDown", 5);
 }
 
-function initializeWhenReady(document) {
-  log("Begin initializeWhenReady", 5);
-  if (isBlacklisted()) {
-    return;
-  }
+function setupListener() {
   document.body.addEventListener(
     "ratechange",
     function(event) {
@@ -391,6 +387,13 @@ function initializeWhenReady(document) {
     },
     true
   );
+}
+
+function initializeWhenReady(document) {
+  log("Begin initializeWhenReady", 5);
+  if (isBlacklisted()) {
+    return;
+  }
   window.onload = () => {
     initializeNow(window.document);
   };
@@ -448,6 +451,11 @@ function initializeNow(document) {
   // enforce init-once due to redundant callers
   if (!document.body || document.body.classList.contains("vsc-initialized")) {
     return;
+  }
+  try {
+    setupListener();
+  } catch {
+    // no operation
   }
   document.body.classList.add("vsc-initialized");
   log("initializeNow: vsc-initialized added to document body", 5);

--- a/inject.js
+++ b/inject.js
@@ -171,16 +171,7 @@ function defineVideoController() {
         // Ignore ratechange events on unitialized videos.
         // 0 == No information is available about the media resource.
         if (event.target.readyState > 0) {
-          var speed = this.getSpeed();
-          this.speedIndicator.textContent = speed;
-          tc.settings.speeds[this.video.currentSrc] = speed;
-          tc.settings.lastSpeed = speed;
-          this.speed = speed;
-          chrome.storage.sync.set({ lastSpeed: speed }, function() {
-            console.log("Speed setting saved: " + speed);
-          });
-          // show the controller for 1000ms if it's hidden.
-          runAction("blink", document, null, null);
+          rateChanged(this);
         }
       }.bind(this))
     );
@@ -584,6 +575,19 @@ function setSpeed(controller, video, speed) {
   var speedIndicator = controller.shadowRoot.querySelector("span");
   speedIndicator.textContent = speedvalue;
   refreshCoolDown();
+}
+
+function rateChanged(controller) {
+  var speed = parseFloat(controller.video.playbackRate).toFixed(2);
+  controller.speedIndicator.textContent = speed;
+  tc.settings.speeds[controller.video.currentSrc] = speed;
+  tc.settings.lastSpeed = speed;
+  controller.speed = speed;
+  chrome.storage.sync.set({ lastSpeed: speed }, function() {
+    console.log("Speed setting saved: " + speed);
+  });
+  // show the controller for 1000ms if it's hidden.
+  runAction("blink", document, null, null);
 }
 
 function runAction(action, document, value, e) {

--- a/inject.js
+++ b/inject.js
@@ -171,7 +171,7 @@ function defineVideoController() {
         // Ignore ratechange events on unitialized videos.
         // 0 == No information is available about the media resource.
         if (event.target.readyState > 0) {
-          rateChanged(this);
+          rateChanged(this.div);
         }
       }.bind(this))
     );
@@ -346,7 +346,6 @@ function initializeWhenReady(document) {
     "ratechange",
     function(event) {
       if (coolDown) {
-        refreshCoolDown();
         console.log("Speed event propagation blocked");
         event.stopImmediatePropagation();
       }
@@ -572,17 +571,19 @@ function initializeNow(document) {
 function setSpeed(controller, video, speed) {
   var speedvalue = speed.toFixed(2);
   video.playbackRate = Number(speedvalue);
-  var speedIndicator = controller.shadowRoot.querySelector("span");
-  speedIndicator.textContent = speedvalue;
   refreshCoolDown();
+  rateChanged(controller);
 }
 
 function rateChanged(controller) {
-  var speed = parseFloat(controller.video.playbackRate).toFixed(2);
-  controller.speedIndicator.textContent = speed;
-  tc.settings.speeds[controller.video.currentSrc] = speed;
+  var speedIndicator = controller.shadowRoot.querySelector("span");
+  var video = controller.parentElement.querySelector("video");
+  var src = video.currentSrc;
+  var speed = video.playbackRate.toFixed(2);
+
+  speedIndicator.textContent = speed;
+  tc.settings.speeds[src] = speed;
   tc.settings.lastSpeed = speed;
-  controller.speed = speed;
   chrome.storage.sync.set({ lastSpeed: speed }, function() {
     console.log("Speed setting saved: " + speed);
   });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
   "homepage_url": "https://github.com/igrigorik/videospeed",
@@ -29,7 +29,6 @@
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/*",
         "https://meet.google.com/*",
-        "https://teamtreehouse.com/*",
         "http://www.hitbox.tv/*"
       ],
       "css": ["inject.css"],

--- a/options.html
+++ b/options.html
@@ -160,13 +160,29 @@
           >Blacklisted sites on which extension is disabled<br />
           (one per line)<br />
           <br />
-          <em
-            ><a href="https://www.regexpal.com/">Regex</a> is supported. Be sure
+          <em>
+            <a href="https://www.regexpal.com/">Regex</a> is supported. Be sure
             it is in "//g" format.<br />
-            ie: /(.+)youtube\.com(\/*)$/gi</em
-          >
+            ie: /(.+)youtube\.com(\/*)$/gi
+          </em>
         </label>
         <textarea id="blacklist" rows="10" cols="50"></textarea>
+      </div>
+      <div class="row">
+        <label for="blacklistrc">
+          Sites to forcefully block ratechange listeners<br />
+          (add here if video speed can't be adjusted or "bounces back" after
+          changing)<br />
+          <br />
+          <em>
+            *Important: Use sparingly as this may cause unexpected website and
+            extension behavior.
+          </em>
+          <br />
+          <br />
+          <em><a href="https://www.regexpal.com/">Regex</a> is supported.</em>
+        </label>
+        <textarea id="blacklistrc" rows="10" cols="50"></textarea>
       </div>
     </section>
 

--- a/options.html
+++ b/options.html
@@ -168,22 +168,6 @@
         </label>
         <textarea id="blacklist" rows="10" cols="50"></textarea>
       </div>
-      <div class="row">
-        <label for="blacklistrc">
-          Sites to forcefully block ratechange listeners<br />
-          (add here if video speed can't be adjusted or "bounces back" after
-          changing)<br />
-          <br />
-          <em>
-            *Important: Use sparingly as this may cause unexpected website and
-            extension behavior.
-          </em>
-          <br />
-          <br />
-          <em><a href="https://www.regexpal.com/">Regex</a> is supported.</em>
-        </label>
-        <textarea id="blacklistrc" rows="10" cols="50"></textarea>
-      </div>
     </section>
 
     <button id="save">Save</button>

--- a/options.js
+++ b/options.js
@@ -23,11 +23,6 @@ var tcDefaults = {
     vine.co
     imgur.com
     teams.microsoft.com
-  `.replace(regStrip, ""),
-  blacklistrc: `\
-    twitch.tv
-    pluralsight.com
-    teamtreehouse.com
   `.replace(regStrip, "")
 };
 
@@ -202,24 +197,6 @@ function validate() {
         }
       }
     });
-  document
-    .getElementById("blacklistrc")
-    .value.split("\n")
-    .forEach(match => {
-      match = match.replace(regStrip, "");
-      if (match.startsWith("/")) {
-        try {
-          var regexp = new RegExp(match);
-        } catch (err) {
-          status.textContent =
-            "Error: Invalid ratechange blacklist regex: " +
-            match +
-            ". Unable to save";
-          valid = false;
-          return;
-        }
-      }
-    });
   return valid;
 }
 
@@ -239,7 +216,6 @@ function save_options() {
   var startHidden = document.getElementById("startHidden").checked;
   var controllerOpacity = document.getElementById("controllerOpacity").value;
   var blacklist = document.getElementById("blacklist").value;
-  var blacklistrc = document.getElementById("blacklistrc").value;
 
   chrome.storage.sync.remove([
     "resetSpeed",
@@ -262,8 +238,7 @@ function save_options() {
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       keyBindings: keyBindings,
-      blacklist: blacklist.replace(regStrip, ""),
-      blacklistrc: blacklistrc.replace(regStrip, "")
+      blacklist: blacklist.replace(regStrip, "")
     },
     function() {
       // Update status to let user know options were saved.
@@ -286,7 +261,6 @@ function restore_options() {
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
     document.getElementById("blacklist").value = storage.blacklist;
-    document.getElementById("blacklistrc").value = storage.blacklistrc;
 
     // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding
     if (storage.keyBindings.filter(x => x.action == "display").length == 0) {

--- a/options.js
+++ b/options.js
@@ -23,6 +23,11 @@ var tcDefaults = {
     vine.co
     imgur.com
     teams.microsoft.com
+  `.replace(regStrip, ""),
+  blacklistrc: `\
+    twitch.tv
+    pluralsight.com
+    teamtreehouse.com
   `.replace(regStrip, "")
 };
 
@@ -191,7 +196,25 @@ function validate() {
           var regexp = new RegExp(match);
         } catch (err) {
           status.textContent =
-            "Error: Invalid Regex: " + match + ". Unable to save";
+            "Error: Invalid blacklist regex: " + match + ". Unable to save";
+          valid = false;
+          return;
+        }
+      }
+    });
+  document
+    .getElementById("blacklistrc")
+    .value.split("\n")
+    .forEach(match => {
+      match = match.replace(regStrip, "");
+      if (match.startsWith("/")) {
+        try {
+          var regexp = new RegExp(match);
+        } catch (err) {
+          status.textContent =
+            "Error: Invalid ratechange blacklist regex: " +
+            match +
+            ". Unable to save";
           valid = false;
           return;
         }
@@ -216,6 +239,7 @@ function save_options() {
   var startHidden = document.getElementById("startHidden").checked;
   var controllerOpacity = document.getElementById("controllerOpacity").value;
   var blacklist = document.getElementById("blacklist").value;
+  var blacklistrc = document.getElementById("blacklistrc").value;
 
   chrome.storage.sync.remove([
     "resetSpeed",
@@ -238,7 +262,8 @@ function save_options() {
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       keyBindings: keyBindings,
-      blacklist: blacklist.replace(regStrip, "")
+      blacklist: blacklist.replace(regStrip, ""),
+      blacklistrc: blacklistrc.replace(regStrip, "")
     },
     function() {
       // Update status to let user know options were saved.
@@ -261,6 +286,7 @@ function restore_options() {
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
     document.getElementById("blacklist").value = storage.blacklist;
+    document.getElementById("blacklistrc").value = storage.blacklistrc;
 
     // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding
     if (storage.keyBindings.filter(x => x.action == "display").length == 0) {


### PR DESCRIPTION
Based on user feedback and my own testing, I'm confident this will fix #584 which has been reported by many users. This should also fix #72 and fix #521 (NOTE: Originally #523 was claimed to be fixed by this in error, that one appears to be related to the apple.tv shadowroot bug)

~I realize in the past we [went back and forth](https://github.com/igrigorik/videospeed/pull/547#issuecomment-569454746) on implementing this or not, however, with one of the largest video sites on the Internet now being impacted I think it is time to bring this fix in. Implementing it with the warnings clearly shown seems to be the lesser of the two evils.~

~To re-iterate, the only known side effect of this fix is that adjusting using the website's controls (assuming it has any) will not update the controller's speed. Adjusting using VSC will immediately fix this by setting the speed to what the VSC says. This is unavoidable, since all ratechange listeners are blocked including ours.~

Edit: See below for notes on the new technique. The caveats listed above no longer apply.