### PR TITLE
Manifest Improvements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "videospeed",
   "version": "0.6.1",
   "manifest_version": 2,
-  "description": "Speed up, slow down, advance and rewind any HTML5 video with quick shortcuts.",
+  "description": "Speed up, slow down, advance and rewind HTML5 audio/video with shortcuts",
   "homepage_url": "https://github.com/igrigorik/videospeed",
   "icons": {
     "16": "icons/icon16.png",
@@ -28,8 +28,7 @@
       "exclude_matches": [
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/*",
-        "https://meet.google.com/*",
-        "http://www.hitbox.tv/*"
+        "https://meet.google.com/*"
       ],
       "css": ["inject.css"],
       "js": ["inject.js"]


### PR DESCRIPTION
1) Removed deprecated URL.
   a. That old hitbox.tv URL does redirect somewhere else now.  Does that site need to be excluded?
   b. Why are sites excluded here vs. being added to the default exclusions list in Options?
2) Shortened description and added "audio" to reflect new functionality
3) The Firefox fork of this extension benefits from adding:
     "options_ui": {
         "page": "options.html"
     }
Would it hurt to add that to this manifest too?