### PR TITLE
Replace deprecated `options_page` key from the manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,10 @@
     "128": "icons/icon128.png"
   },
   "permissions": ["activeTab", "storage"],
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "browser_action": {
     "default_icon": {
       "19": "icons/icon19.png",


### PR DESCRIPTION
The `options_page` key from the manifest is deprecated in favor of `options_ui`
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page.

This is from the Firefox port of VSC and shouldn't afect Chrome in any way.
