### PR TITLE
Prevent event bubbling when clicking or dragging

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -286,20 +286,37 @@ function defineVideoController() {
         </div>
       `;
     shadow.innerHTML = shadowTemplate;
-    shadow.querySelector(".draggable").addEventListener("mousedown", e => {
-      runAction(e.target.dataset["action"], document, false, e);
-    });
+    shadow.querySelector(".draggable").addEventListener(
+      "mousedown",
+      e => {
+        runAction(e.target.dataset["action"], document, false, e);
+        e.stopPropagation();
+      },
+      true
+    );
 
     forEach.call(shadow.querySelectorAll("button"), function(button) {
-      button.onclick = e => {
-        runAction(
-          e.target.dataset["action"],
-          document,
-          getKeyBindings(e.target.dataset["action"]),
-          e
-        );
-      };
+      button.addEventListener(
+        "click",
+        e => {
+          runAction(
+            e.target.dataset["action"],
+            document,
+            getKeyBindings(e.target.dataset["action"]),
+            e
+          );
+          e.stopPropagation();
+        },
+        true
+      );
     });
+
+    shadow
+      .querySelector("#controller")
+      .addEventListener("click", e => e.stopPropagation(), false);
+    shadow
+      .querySelector("#controller")
+      .addEventListener("mousedown", e => e.stopPropagation(), false);
 
     this.speedIndicator = shadow.querySelector("span");
     var fragment = document.createDocumentFragment();


### PR DESCRIPTION
Prevent additional unwanted actions, like entering fullscreen or pausing 
the video, when clicking VSC buttons or dragging the VSC controller.

Fixes igrigorik/videospeed#425, igrigorik/videospeed#512, codebicycle/videospeed#80.