### PR TITLE
Fix #632 speed display not updating on Amazon video

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -382,11 +382,8 @@ function setupListener() {
         log("Speed event propagation blocked", 4);
         event.stopImmediatePropagation();
       }
-      var controller = event.target.parentElement.querySelector(
-        ".vsc-controller"
-      );
-      var speedIndicator = controller.shadowRoot.querySelector("span");
-      var video = controller.parentElement.querySelector("video");
+      var video = event.target;
+      var speedIndicator = video.vsc.speedIndicator;
       var src = video.currentSrc;
       var speed = video.playbackRate.toFixed(2);
 


### PR DESCRIPTION
This fixes issue #632 where the display speed isn't updated on Amazon, HBOGo and Reddit.  On those sites, the controls are inserted into the DOM in a different place, and the code that goes to update the speed indicator isn't looking in the correct spot.