### PR TITLE
affects #659 and #626 to allow a new option to force apply prefered speed

### DIFF
--- a/options.html
+++ b/options.html
@@ -148,6 +148,11 @@
         <input id="rememberSpeed" type="checkbox" />
       </div>
       <div class="row">
+        <label for="forceLastSavedSpeed">Force last saved speed<br />
+        <em>Useful for video players that override the speeds set by VideoSpeed</em></label>
+        <input id="forceLastSavedSpeed" type="checkbox" />
+      </div>
+      <div class="row">
         <label for="audioBoolean">Work on audio</label>
         <input id="audioBoolean" type="checkbox" />
       </div>

--- a/options.js
+++ b/options.js
@@ -6,6 +6,7 @@ var tcDefaults = {
   rememberSpeed: false, // default: false
   audioBoolean: false, // default: false
   startHidden: false, // default: false
+  forceLastSavedSpeed: false, //default: false
   enabled: true, // default enabled
   controllerOpacity: 0.3, // default: 0.3
   keyBindings: [
@@ -209,6 +210,7 @@ function save_options() {
   ); // Remove added shortcuts
 
   var rememberSpeed = document.getElementById("rememberSpeed").checked;
+  var forceLastSavedSpeed = document.getElementById("forceLastSavedSpeed").checked;
   var audioBoolean = document.getElementById("audioBoolean").checked;
   var enabled = document.getElementById("enabled").checked;
   var startHidden = document.getElementById("startHidden").checked;
@@ -231,6 +233,7 @@ function save_options() {
   chrome.storage.sync.set(
     {
       rememberSpeed: rememberSpeed,
+      forceLastSavedSpeed: forceLastSavedSpeed,
       audioBoolean: audioBoolean,
       enabled: enabled,
       startHidden: startHidden,
@@ -253,6 +256,7 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get(tcDefaults, function (storage) {
     document.getElementById("rememberSpeed").checked = storage.rememberSpeed;
+    document.getElementById("forceLastSavedSpeed").checked = storage.forceLastSavedSpeed;
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("enabled").checked = storage.enabled;
     document.getElementById("startHidden").checked = storage.startHidden;


### PR DESCRIPTION
### What has been done?
- introduced a new setting that allows video speed to force apply the
preferred speed on video players.
   - this is a fix/workaround for video players that reapply their native speed
   settings over video speed, even when the preferred speed setting is
   enabled.  This also applies to instances where the speed would be
   reset due to the native video player emiting their native speed on
   media events like seek, pause, play and buffering instances.