### PR TITLE
fix for tofixed on string error

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -411,12 +411,12 @@ function setupListener() {
       var video = event.target;
       var speedIndicator = video.vsc.speedIndicator;
       var src = video.currentSrc;
-      var speed = video.playbackRate.toFixed(2);
+      var speed = Number(video.playbackRate.toFixed(2));
 
       log("Playback rate changed to " + speed, 4);
 
       log("Updating controller with new speed", 5);
-      speedIndicator.textContent = speed;
+      speedIndicator.textContent = speed.toFixed(2);
       tc.settings.speeds[src] = speed;
       log("Storing lastSpeed in settings for the rememberSpeed feature", 5);
       tc.settings.lastSpeed = speed;


### PR DESCRIPTION
Fixes #666,
Problem: tc.settings.speeds[src] became a string which toFixed  can't handle.
Now before getting saved in tc.settings.speed[src] it gets converted to a number.

Line 419 is added so you see 2.00 instead of 2 in the top corner.

Made a merge request because tarunlalwani didn't respond anymore on his pull request.(made a comment 20 days ago) https://github.com/igrigorik/videospeed/pull/669