### PR TITLE
proof-of-concept: display saved duration in extension icon's badge

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,46 @@
+let savedTimerFormatDuration = function(ms) {
+  let seconds = ms / 1000;
+  let h = Math.floor(seconds/3600);
+  let m = Math.floor((seconds - 3600*h) / 60);
+  let s = Math.floor(seconds - 3600*h - 60*m);
+  console.info(`saved duration: ${h}h:${m}m:${s}s`);
+  if (h === 0 && m === 0) {
+    return `${s}s`;
+  } else {
+    return `${m}m`;
+  }
+}
+
+let savedTimerReset = function() {
+  chrome.storage.sync.remove('saved_durations');
+}
+
+chrome.runtime.onMessage.addListener(
+  function(request, sender, sendResponse) {
+    console.info("request", request);
+
+    let vscid = request.vscid;
+
+    chrome.storage.sync.get({saved_durations: {}}, function(store) {
+      console.info("store:", store);
+
+      if(store.saved_durations[vscid] == null)
+        store.saved_durations[vscid] = 0;
+
+      if(request.add) {
+        store.saved_durations[vscid] = store.saved_durations[vscid] + request.duration;
+        delete store.saved_durations["tmp."+vscid];
+      } else {
+        store.saved_durations["tmp."+vscid] = request.duration;
+      }
+
+      let sum = 0;
+      Object
+        .values(store.saved_durations)
+        .forEach(d => sum += d);
+
+      chrome.storage.sync.set(store);
+      chrome.browserAction.setBadgeText({text: savedTimerFormatDuration(sum)});
+    });
+  },
+);

--- a/manifest.json
+++ b/manifest.json
@@ -37,5 +37,8 @@
       "js": ["inject.js"]
     }
   ],
+  "background": {
+    "scripts": ["background.js"]
+  },
   "web_accessible_resources": ["inject.css", "shadow.css"]
 }


### PR DESCRIPTION
As promised in #185, here is a proof-of-concept for showing the total saved time on top of the extension icon. I wanted to see how it could work. My conclusion is that it adds too much complexity for a feature that is not of critical importance for the maintainers of the project. So, I don't recommend it being merged. However, feel free to use it as the basis for your own experimentations. :)

Here's a screenshot of the badge indicating 9 minutes of saved time (in total, for all videos in all tabs since the extension was installed).

![Screen Shot 2020-07-21 at 00 43 14](https://user-images.githubusercontent.com/364548/87981864-2bd92d80-caeb-11ea-8476-4c6aedc91645.png)

