### PR TITLE
Fix deletion when aria-hidden is set

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -652,15 +652,8 @@ function initializeNow(document) {
                   (x) => x.tagName == "VIDEO"
                 )[0];
                 if (node) {
-                  var oldController = flattenedNodes.filter((x) =>
-                    x.classList.contains("vsc-controller")
-                  )[0];
-                  if (oldController) {
-                    oldController.remove();
-                    if (node.vsc) {
-                      delete node.vsc;
-                    }
-                  }
+                  if (node.vsc)
+                    node.vsc.remove();
                   checkForVideo(node, node.parentNode || mutation.target, true);
                 }
               }


### PR DESCRIPTION
This fixes the error issue that @pepijnmm found (described in #708 ).  It does not fix the issue with pluralsite resetting the speed.  The best I can tell, I think the pluralsite player resets the speed to whatever it's control is set to after videospeed sets it.