### PR TITLE
fixes an issue with pluralsight causing speed to revert back to 1, after passing 2

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -467,6 +467,7 @@ function setupListener() {
         } else {
           video.playbackRate = tc.settings.lastSpeed;
         }
+        event.stopImmediatePropagation();
       } else {
         updateSpeedFromEvent(video);
       }


### PR DESCRIPTION

affects #661

What has been done?
- Events being fired by both the video provider as well as VideoSpeed was causing too many events to occur, causing the disregarding of VideoSpeed's forced event.  To prevent this, we immediately stop the immediate propagation of the event instead.