### PR TITLE
fix control position on hulu w/ getBoundingClientRect 

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -272,8 +272,8 @@ function defineVideoController() {
   tc.videoController.prototype.initializeControls = function () {
     log("initializeControls Begin", 5);
     const document = this.video.ownerDocument;
-    const rect = this.video.getBoundingClientRect();
     const speed = this.video.playbackRate.toFixed(2);
+    const rect = this.video.getBoundingClientRect();
     const top = Math.max(rect.top, 0) + "px";
     const left = Math.max(rect.left, 0) + "px";
 

--- a/inject.js
+++ b/inject.js
@@ -271,10 +271,11 @@ function defineVideoController() {
 
   tc.videoController.prototype.initializeControls = function () {
     log("initializeControls Begin", 5);
-    var document = this.video.ownerDocument;
-    var speed = this.video.playbackRate.toFixed(2),
-      top = Math.max(this.video.offsetTop, 0) + "px",
-      left = Math.max(this.video.offsetLeft, 0) + "px";
+    const document = this.video.ownerDocument;
+    const rect = this.video.getBoundingClientRect();
+    const speed = this.video.playbackRate.toFixed(2);
+    const top = Math.max(rect.top, 0) + "px";
+    const left = Math.max(rect.left, 0) + "px";
 
     log("Speed variable set to: " + speed, 5);
 


### PR DESCRIPTION
On hulu's desktop web client, the video is stretched to "fullscreen" with transforms!

![image](https://user-images.githubusercontent.com/39191/105283922-46f22c00-5b66-11eb-92db-9ebabc2fc1a6.png)

This means the technique to correctly position the controls puts them right in the middle of the video.

`getBoundingClientRect` takes transforms into account, but otherwise I think it has consistent semantics with `offsetLeft`/`offsetTop`. (i tested with adding extra margin and extra border and box-sizing..... and the results are the same)

I tested with hulu, youtube, netflix, facebook and they're all lookin fine.

fixes #562. fixes #744 
