### PR TITLE
enforce normal white-space rendering for controller

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -9,6 +9,11 @@
   opacity: 1 !important;
 }
 
+.vsc-controller {
+  /* In case of pages using `white-space: pre-line` (eg Discord), don't render vsc's whitespace */
+  white-space: normal;
+}
+
 /* Origin specific overrides */
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {


### PR DESCRIPTION
fixes #746 


| before | after |
|-|-|
| ![image](https://user-images.githubusercontent.com/39191/105288930-da2e6000-5b6c-11eb-9e00-7067c8aed578.png) |![image](https://user-images.githubusercontent.com/39191/105286980-2d53e300-5b6c-11eb-8b98-7d51d525d8ad.png) |



note on the css placement: while there are origin-specific fixes, it feels like this defensive style can afford to be _always_ be present. 
(also, placing the style within shadow.css was my preference, unfortunately it's incomplete: while applying to #controller fixes the layout of the buttons, there's still excessive whitespace remaining)