### PR TITLE
Add honeycode.aws to blacklist (videospeed mangles the site)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -19,6 +19,7 @@ var tc = {
       vine.co
       imgur.com
       teams.microsoft.com
+      honeycode.aws
     `.replace(regStrip, ""),
     defaultLogLevel: 4,
     logLevel: 3


### PR DESCRIPTION
See #754

I'm not sure what's causing the issue, but this adds the site to the blacklist until it gets fixed.
