### PR TITLE
Reset the position of controller to the top left

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -273,9 +273,8 @@ function defineVideoController() {
     log("initializeControls Begin", 5);
     const document = this.video.ownerDocument;
     const speed = this.video.playbackRate.toFixed(2);
-    const rect = this.video.getBoundingClientRect();
-    const top = Math.min(rect.top, 0) + "px";
-    const left = Math.min(rect.left, 0) + "px";
+    const top = Math.max(this.video.offsetTop, 0) + "px";
+    const left = Math.max(this.video.offsetLeft, 0) + "px";
 
     log("Speed variable set to: " + speed, 5);
 

--- a/inject.js
+++ b/inject.js
@@ -274,8 +274,8 @@ function defineVideoController() {
     const document = this.video.ownerDocument;
     const speed = this.video.playbackRate.toFixed(2);
     const rect = this.video.getBoundingClientRect();
-    const top = Math.max(rect.top, 0) + "px";
-    const left = Math.max(rect.left, 0) + "px";
+    const top = Math.min(rect.top, 0) + "px";
+    const left = Math.min(rect.left, 0) + "px";
 
     log("Speed variable set to: " + speed, 5);
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind HTML5 audio/video with shortcuts",
   "homepage_url": "https://github.com/igrigorik/videospeed",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Video Speed Controller",
   "short_name": "videospeed",
-  "version": "0.6.5",
+  "version": "0.6.3",
   "manifest_version": 2,
   "description": "Speed up, slow down, advance and rewind HTML5 audio/video with shortcuts",
   "homepage_url": "https://github.com/igrigorik/videospeed",


### PR DESCRIPTION
The positioning of the controller was getting overridden by the element.style.
Added "!important" to keep the controller in the top left by default.