### PR TITLE
Update to work with the latest Apple TV

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -361,8 +361,7 @@ function defineVideoController() {
         p.insertBefore(fragment, p.firstChild);
         break;
       case location.hostname == "tv.apple.com":
-        // insert after parent for correct stacking context
-        this.parent.getRootNode().querySelector(".scrim").prepend(fragment);
+        // pass-through, the latest version of AppleTV works with default behavior
       default:
         // Note: when triggered via a MutationRecord, it's possible that the
         // target is not the immediate parent. This appends the controller as
@@ -646,14 +645,15 @@ function initializeNow(document) {
               break;
             case "attributes":
               if (
-                mutation.target.attributes["aria-hidden"] &&
-                mutation.target.attributes["aria-hidden"].value == "false"
+                (mutation.target.attributes["aria-hidden"] &&
+                mutation.target.attributes["aria-hidden"].value == "false")
+                || mutation.target.nodeName === 'APPLE-TV-PLUS-PLAYER'
               ) {
                 var flattenedNodes = getShadow(document.body);
-                var node = flattenedNodes.filter(
+                var nodes = flattenedNodes.filter(
                   (x) => x.tagName == "VIDEO"
-                )[0];
-                if (node) {
+                );
+                for (let node of nodes) {
                   if (node.vsc)
                     node.vsc.remove();
                   checkForVideo(node, node.parentNode || mutation.target, true);
@@ -667,7 +667,7 @@ function initializeNow(document) {
     );
   });
   observer.observe(document, {
-    attributeFilter: ["aria-hidden"],
+    attributes: true,
     childList: true,
     subtree: true
   });

--- a/inject.js
+++ b/inject.js
@@ -361,7 +361,9 @@ function defineVideoController() {
         p.insertBefore(fragment, p.firstChild);
         break;
       case location.hostname == "tv.apple.com":
-        // pass-through, the latest version of AppleTV works with default behavior
+        // insert before parent to bypass overlay
+        this.parent.parentNode.insertBefore(fragment, this.parent.parentNode.firstChild);
+        break;
       default:
         // Note: when triggered via a MutationRecord, it's possible that the
         // target is not the immediate parent. This appends the controller as
@@ -654,6 +656,9 @@ function initializeNow(document) {
                   (x) => x.tagName == "VIDEO"
                 );
                 for (let node of nodes) {
+                  // only add vsc the first time for the apple-tv case (the attribute change is triggered every time you click the vsc)
+                  if (node.vsc && mutation.target.nodeName === 'APPLE-TV-PLUS-PLAYER')
+                    continue;
                   if (node.vsc)
                     node.vsc.remove();
                   checkForVideo(node, node.parentNode || mutation.target, true);
@@ -667,7 +672,7 @@ function initializeNow(document) {
     );
   });
   observer.observe(document, {
-    attributes: true,
+    attributeFilter: ["aria-hidden", "data-focus-method"],
     childList: true,
     subtree: true
   });


### PR DESCRIPTION
The old insertion code no longer works, and the change that allows injection into apple-tv-plus-player is a different attribute change than 'aria-hidden'