### PR TITLE
speed not showing: if (offsetRect===undefined) { document.documentElement.appendChild(fragment)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -373,7 +373,11 @@ function defineVideoController() {
         // Note: when triggered via a MutationRecord, it's possible that the
         // target is not the immediate parent. This appends the controller as
         // the first element of the target, which may not be the parent.
-        this.parent.insertBefore(fragment, this.parent.firstChild);
+        if (offsetRect===undefined) {
+          document.documentElement.appendChild(fragment)
+        } else {
+          this.parent.insertBefore(fragment, this.parent.firstChild);
+        }
     }
     return wrapper;
   };


### PR DESCRIPTION
speed not showing on https://music.youtube.com/
I hope this fallback works on every website
I like that it's at `top:0px; left:0px;` because it doesn't hide part of the video

can someone explain why
`document.documentElement.appendChild(fragment)` works
but
`this.parent.insertBefore(fragment, this.parent.firstChild);` doesn't ?
I can see that the element IS there. by searching (in chrome inspect element) `"drag"`, but it isn't displayed ?

___
I think `Hide controller by default` should be enabled by default, or else it's obtrusive
and `Controller opacity` at least 0.8 for it to easily be seen in a dark background