### PR TITLE
Modern settings redesign with auto dark mode

### DIFF
--- a/options.css
+++ b/options.css
@@ -1,112 +1,151 @@
-body {
+/* Reset browser defaults */
+* {
+  box-sizing: border-box;
   margin: 0;
-  padding-left: 15px;
-  padding-top: 53px;
-  font-family: sans-serif;
-  font-size: 12px;
-  color: rgb(48, 57, 66);
+  padding: 0;
 }
 
-h1,
-h2,
-h3 {
-  font-weight: normal;
-  line-height: 1;
-  user-select: none;
-  cursor: default;
+:root {
+  --dark: 36 38 40;
+
+  --light-gray: #eee;
+  --gray: #dedede;
+  --dark-gray: #9d9d9d;
+
+  --gutter: 1.75rem;
 }
-h1 {
-  font-size: 1.5em;
-  margin: 21px 0 13px;
+
+:any-link {
+  color: inherit;
 }
-h3 {
-  font-size: 1.2em;
-  margin-bottom: 0.8em;
-  color: black;
-}
-p {
-  margin: 0.65em 0;
+
+body {
+  color: rgb(var(--dark));
+  font-size: .875rem; /* 14 px */
 }
 
 header {
-  position: fixed;
-  top: 0;
-  left: 15px;
-  right: 0;
-  border-bottom: 1px solid #eee;
-  background: linear-gradient(white, white 40%, rgba(255, 255, 255, 0.92));
-}
-header,
-section {
-  min-width: 600px;
-  max-width: 738px;
-}
-section {
-  padding-left: 18px;
-  margin-top: 8px;
-  margin-bottom: 24px;
-}
-section h3 {
-  margin-left: -18px;
-}
-
-button {
-  -webkit-appearance: none;
-  position: relative;
-
-  margin: 0 1px 0 0;
-  padding: 0 10px;
-  min-width: 4em;
-  min-height: 2em;
-
-  background-image: linear-gradient(#ededed, #ededed 38%, #dedede);
-  border: 1px solid rgba(0, 0, 0, 0.25);
-  border-radius: 2px;
-  outline: none;
-  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08),
-    inset 0 1px 2px rgba(255, 255, 255, 0.75);
-  color: #444;
-  text-shadow: 0 1px 0 rgb(240, 240, 240);
-  font: inherit;
-
-  user-select: none;
-}
-
-input[type="text"] {
-  width: 75px;
+  backdrop-filter: blur(8px);
+  background: rgba(255 255 255 / .75);
+  border-bottom: 2px solid var(--light-gray);
+  position: sticky;
   text-align: center;
+  top: 0;
+  z-index: 1;
+}
+
+main {
+  margin: 0 auto;
+  max-width: 700px;
+  padding: 0 var(--gutter);
+}
+
+section,
+#faq {
+  margin: var(--gutter) 0;
+}
+
+/* Header title */
+h1 {
+  font-size: 1.5rem;
+  font-weight: bold;
+  padding: .75em;
+}
+
+/* Section titles */
+h3,
+h4 {
+  font-weight: 600;
+  margin: 1em 0 .25em;
+}
+
+h3 {
+  font-size: 1.25rem;
+}
+
+h4 {
+  font-size: 1rem;
+}
+
+p {
+  margin-bottom: .5em;
 }
 
 .row {
-  margin: 5px 0px;
+  margin: .5rem 0;
+}
+
+select,
+input,
+button {
+  font: inherit;
+  margin-right: .25rem;
+}
+
+select {
+  width: 11rem;
+}
+
+input[type="text"] {
+  text-align: center;
+  width: 5rem;
+}
+
+button {
+  background: var(--light-gray);
+  border-radius: 5px;
+  border: 1px solid rgba(var(--dark) / 0.25);
+  box-shadow: 0 2px 3px rgba(var(--dark) / .08),
+        inset 0 -2px 3px rgba(var(--dark) / .15);
+  color: rgba(var(--dark) / .9);
+  padding: .5em 1em;
+  text-shadow: 0 1px 1px var(--light-gray);
+}
+
+/* "X" to remove new shortcuts */
+button.removeParent {
+  padding: 1px;
+  width: 3em;
+}
+
+/* (Do not) disable website keybindings */
+.customForce {
+  display: none;
+  width: 16rem;
 }
 
 label {
   display: inline-block;
-  width: 170px;
+  margin-right: .75rem;
   vertical-align: top;
+  width: 12.5rem;
 }
 
+/* e.g. "Default options restored" */
 #status {
-  color: #9d9d9d;
+  color: var(--dark-gray);
   display: inline-block;
-  margin-left: 50px;
 }
 
-#faq {
-  margin-top: 2em;
+ol {
+  margin-left: 2.5rem;
 }
 
-select {
-  width: 170px;
+hr {
+  border: 2px dashed var(--light-gray);
 }
 
-.customForce {
-  display: none;
-  width: 250px;
-}
+@media (prefers-color-scheme: dark) {
+  body {
+    background: rgb(var(--dark));
+    color: white;
+  }
 
-.customKey {
-  color: transparent;
-  text-shadow: 0 0 0 #000000;
+  header {
+    background: rgb(var(--dark) / .85);
+  }
+
+  #status {
+    color: var(--gray);
+  }
 }

--- a/options.css
+++ b/options.css
@@ -1,17 +1,16 @@
 /* Reset browser defaults */
-* {
+*,
+*::after,
+*::before {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 :root {
-  --dark: 36 38 40;
-
-  --light-gray: #eee;
-  --gray: #dedede;
-  --dark-gray: #9d9d9d;
-
+  --clr-main: 255 255 255;
+  --clr-primary-gray: 112 112 112;
+  --clr-secondary-gray: 238 238 238;
   --gutter: 1.75rem;
 }
 
@@ -20,14 +19,14 @@
 }
 
 body {
-  color: rgb(var(--dark));
-  font-size: .875rem; /* 14 px */
+  color: #212121;
+  font: .875rem system-ui;
 }
 
 header {
   backdrop-filter: blur(8px);
-  background: rgba(255 255 255 / .75);
-  border-bottom: 2px solid var(--light-gray);
+  background: rgba(var(--clr-main) / .85);
+  border-bottom: 2px solid rgb(var(--clr-secondary-gray));
   position: sticky;
   text-align: center;
   top: 0;
@@ -72,34 +71,30 @@ p {
 }
 
 .row {
-  margin: .5rem 0;
+  margin: .5em 0;
 }
 
 select,
 input,
 button {
   font: inherit;
-  margin-right: .25rem;
+  margin-right: .35em;
 }
 
 select {
-  width: 11rem;
+  width: 12em;
 }
 
 input[type="text"] {
   text-align: center;
-  width: 5rem;
+  width: 6em;
 }
 
 button {
-  background: var(--light-gray);
-  border-radius: 5px;
-  border: 1px solid rgba(var(--dark) / 0.25);
-  box-shadow: 0 2px 3px rgba(var(--dark) / .08),
-        inset 0 -2px 3px rgba(var(--dark) / .15);
-  color: rgba(var(--dark) / .9);
+  border-radius: .5em;
+  border: 1px solid rgba(0 0 0 / 0.25);
+  box-shadow: 0 2px 3px rgba(0 0 0 / .08), inset 0 -2px 3px rgba(0 0 0 / .15);
   padding: .5em 1em;
-  text-shadow: 0 1px 1px var(--light-gray);
 }
 
 /* "X" to remove new shortcuts */
@@ -111,41 +106,38 @@ button.removeParent {
 /* (Do not) disable website keybindings */
 .customForce {
   display: none;
-  width: 16rem;
+  width: 18.5em;
 }
 
 label {
   display: inline-block;
   margin-right: .75rem;
   vertical-align: top;
-  width: 12.5rem;
+  width: 14em;
 }
 
 /* e.g. "Default options restored" */
 #status {
-  color: var(--dark-gray);
+  color: rgb(var(--clr-primary-gray));
   display: inline-block;
 }
 
 ol {
-  margin-left: 2.5rem;
+  margin-left: 3em;
 }
 
 hr {
-  border: 2px dashed var(--light-gray);
+  border: 2px dashed rgb(var(--clr-secondary-gray));
 }
 
 @media (prefers-color-scheme: dark) {
+  :root {
+    --clr-main: 36 38 40;
+    --clr-primary-gray: 238 238 238;
+    --clr-secondary-gray: 112 112 112;
+  }
+
   body {
-    background: rgb(var(--dark));
-    color: white;
-  }
-
-  header {
-    background: rgb(var(--dark) / .85);
-  }
-
-  #status {
-    color: var(--gray);
+    color: #fff;
   }
 }

--- a/options.css
+++ b/options.css
@@ -97,6 +97,10 @@ button {
   padding: .5em 1em;
 }
 
+button:active {
+  box-shadow: inset 0 -1px 3px rgba(0 0 0 / .15);
+}
+
 /* "X" to remove new shortcuts */
 button.removeParent {
   padding: 1px;

--- a/options.html
+++ b/options.html
@@ -195,13 +195,13 @@
         browser:
       </p>
 
-      <ul>
+      <ol>
         <li>
           In a new tab, navigate to <code>chrome://settings/content/flash</code>
         </li>
         <li>Disable "Allow sites to run Flash"</li>
         <li>Restart your browser and try playing your audio or video again</li>
-      </ul>
+      </ol>
 
       <h4>The speed controls are not showing up for local videos?</h4>
       <p>
@@ -209,7 +209,7 @@
         to grant additional permissions to the extension.
       </p>
 
-      <ul>
+      <ol>
         <li>In a new tab, navigate to <code>chrome://extensions</code></li>
         <li>
           Find "Video Speed Controller" extension in the list and enable "Allow
@@ -219,7 +219,7 @@
           Open a new tab and try opening a local file, the controls should show
           up
         </li>
-      </ul>
+      </ol>
     </div>
   </body>
 </html>

--- a/options.html
+++ b/options.html
@@ -8,181 +8,184 @@
   <h1>Video Speed Controller</h1>
 </header>
 
-<section id="customs">
-  <h3>Shortcuts</h3>
-  <div class="row customs" id="display">
-    <select class="customDo">
-      <option value="display">Show/hide controller</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (0.10)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="slower">
-    <select class="customDo">
-      <option value="slower">Decrease speed</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (0.10)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="faster">
-    <select class="customDo">
-      <option value="faster">Increase speed</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (0.10)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="rewind">
-    <select class="customDo">
-      <option value="rewind">Rewind</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (10)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="advance">
-    <select class="customDo">
-      <option value="advance">Advance</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (10)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="reset">
-    <select class="customDo">
-      <option value="reset">Reset speed</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input
-      class="customValue"
-      type="text"
-      placeholder="value (1.00)"
-      disabled
-    />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
-  <div class="row customs" id="fast">
-    <select class="customDo">
-      <option value="fast">Preferred speed</option>
-    </select>
-    <input class="customKey" type="text" value="" placeholder="press a key" />
-    <input class="customValue" type="text" placeholder="value (1.80)" />
-    <select class="customForce">
-      <option value="false">Do not disable website key bindings</option>
-      <option value="true">Disable website key bindings</option>
-    </select>
-  </div>
+<main>
+  <section id="customs">
+    <h3>Shortcuts</h3>
+    <div class="row customs" id="display">
+      <select class="customDo">
+        <option value="display">Show/hide controller</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (0.10)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="slower">
+      <select class="customDo">
+        <option value="slower">Decrease speed</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (0.10)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="faster">
+      <select class="customDo">
+        <option value="faster">Increase speed</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (0.10)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="rewind">
+      <select class="customDo">
+        <option value="rewind">Rewind</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (10)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="advance">
+      <select class="customDo">
+        <option value="advance">Advance</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (10)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="reset">
+      <select class="customDo">
+        <option value="reset">Reset speed</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input
+        class="customValue"
+        type="text"
+        placeholder="value (1.00)"
+        disabled
+      />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
+    <div class="row customs" id="fast">
+      <select class="customDo">
+        <option value="fast">Preferred speed</option>
+      </select>
+      <input class="customKey" type="text" value="" placeholder="press a key" />
+      <input class="customValue" type="text" placeholder="value (1.80)" />
+      <select class="customForce">
+        <option value="false">Do not disable website key bindings</option>
+        <option value="true">Disable website key bindings</option>
+      </select>
+    </div>
 
-  <button id="add">Add New</button>
-</section>
+    <button id="add">Add New</button>
+  </section>
 
-<section>
-  <h3>Other</h3>
-  <div class="row">
-    <label for="enabled">Enable</label>
-    <input id="enabled" type="checkbox" />
+  <section>
+    <h3>Other</h3>
+    <div class="row">
+      <label for="enabled">Enable</label>
+      <input id="enabled" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="startHidden">Hide controller by default</label>
+      <input id="startHidden" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="rememberSpeed">Remember playback speed</label>
+      <input id="rememberSpeed" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="forceLastSavedSpeed"
+        >Force last saved speed<br />
+        <em
+          >Useful for video players that override the speeds set by
+          VideoSpeed</em
+        ></label
+      >
+      <input id="forceLastSavedSpeed" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="audioBoolean">Work on audio</label>
+      <input id="audioBoolean" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="controllerOpacity">Controller opacity</label>
+      <input id="controllerOpacity" type="text" value="" />
+    </div>
+    <div class="row">
+      <label for="blacklist"
+        >Sites on which extension is disabled<br />
+        (one per line)<br />
+        <br />
+        <em>
+          <a href="https://www.regexpal.com/">Regex</a> is supported.<br />
+          Be sure to use the literal notation.<br />
+          ie: /(.+)youtube\.com(\/*)$/gi
+        </em>
+      </label>
+      <textarea id="blacklist" rows="10" cols="50"></textarea>
+    </div>
+  </section>
+
+  <button id="save">Save</button>
+  <button id="restore">Restore Defaults</button>
+  <button id="experimental">Show Experimental Features</button>
+
+  <div id="status"></div>
+
+  <div id="faq">
+    <hr />
+
+    <h4>Extension controls not appearing?</h4>
+    <p>
+      This extension is only compatible with HTML5 audio and video. If you don't
+      see the controls showing up, chances are you are viewing a Flash content.
+      If you want to confirm, try right-clicking on the content and inspect the
+      menu: if it mentions flash, then that's the issue. That said,
+      <b>most sites will fallback to HTML5</b> if they detect that Flash is not
+      available. You can try manually disabling Flash plugin in the browser:
+    </p>
+
+    <ol>
+      <li>
+        In a new tab, navigate to <code>chrome://settings/content/flash</code>
+      </li>
+      <li>Disable "Allow sites to run Flash"</li>
+      <li>Restart your browser and try playing your audio or video again</li>
+    </ol>
+
+    <h4>The speed controls are not showing up for local videos?</h4>
+    <p>
+      To enable playback of local media (e.g. File &gt; Open File), you need to
+      grant additional permissions to the extension.
+    </p>
+
+    <ol>
+      <li>In a new tab, navigate to <code>chrome://extensions</code></li>
+      <li>
+        Find "Video Speed Controller" extension in the list and enable "Allow
+        access to file URLs"
+      </li>
+      <li>
+        Open a new tab and try opening a local file, the controls should show up
+      </li>
+    </ol>
   </div>
-  <div class="row">
-    <label for="startHidden">Hide controller by default</label>
-    <input id="startHidden" type="checkbox" />
-  </div>
-  <div class="row">
-    <label for="rememberSpeed">Remember playback speed</label>
-    <input id="rememberSpeed" type="checkbox" />
-  </div>
-  <div class="row">
-    <label for="forceLastSavedSpeed"
-      >Force last saved speed<br />
-      <em
-        >Useful for video players that override the speeds set by VideoSpeed</em
-      ></label
-    >
-    <input id="forceLastSavedSpeed" type="checkbox" />
-  </div>
-  <div class="row">
-    <label for="audioBoolean">Work on audio</label>
-    <input id="audioBoolean" type="checkbox" />
-  </div>
-  <div class="row">
-    <label for="controllerOpacity">Controller opacity</label>
-    <input id="controllerOpacity" type="text" value="" />
-  </div>
-  <div class="row">
-    <label for="blacklist"
-      >Sites on which extension is disabled<br />
-      (one per line)<br />
-      <br />
-      <em>
-        <a href="https://www.regexpal.com/">Regex</a> is supported.<br />
-        Be sure to use the literal notation.<br />
-        ie: /(.+)youtube\.com(\/*)$/gi
-      </em>
-    </label>
-    <textarea id="blacklist" rows="10" cols="50"></textarea>
-  </div>
-</section>
-
-<button id="save">Save</button>
-<button id="restore">Restore Defaults</button>
-<button id="experimental">Show Experimental Features</button>
-
-<div id="status"></div>
-
-<div id="faq">
-  <hr />
-
-  <h4>Extension controls not appearing?</h4>
-  <p>
-    This extension is only compatible with HTML5 audio and video. If you don't
-    see the controls showing up, chances are you are viewing a Flash content. If
-    you want to confirm, try right-clicking on the content and inspect the menu:
-    if it mentions flash, then that's the issue. That said,
-    <b>most sites will fallback to HTML5</b> if they detect that Flash is not
-    available. You can try manually disabling Flash plugin in the browser:
-  </p>
-
-  <ol>
-    <li>
-      In a new tab, navigate to <code>chrome://settings/content/flash</code>
-    </li>
-    <li>Disable "Allow sites to run Flash"</li>
-    <li>Restart your browser and try playing your audio or video again</li>
-  </ol>
-
-  <h4>The speed controls are not showing up for local videos?</h4>
-  <p>
-    To enable playback of local media (e.g. File &gt; Open File), you need to
-    grant additional permissions to the extension.
-  </p>
-
-  <ol>
-    <li>In a new tab, navigate to <code>chrome://extensions</code></li>
-    <li>
-      Find "Video Speed Controller" extension in the list and enable "Allow
-      access to file URLs"
-    </li>
-    <li>
-      Open a new tab and try opening a local file, the controls should show up
-    </li>
-  </ol>
-</div>
+</main>

--- a/options.html
+++ b/options.html
@@ -1,225 +1,188 @@
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>Video Speed Controller: Options</title>
-    <link rel="stylesheet" href="options.css" />
-    <script src="options.js"></script>
-  </head>
-  <body>
-    <header>
-      <h1>Video Speed Controller</h1>
-    </header>
 
-    <section id="customs">
-      <h3>Shortcuts</h3>
-      <div class="row customs" id="display">
-        <select class="customDo">
-          <option value="display">Show/hide controller</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (0.10)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="slower">
-        <select class="customDo">
-          <option value="slower">Decrease speed</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (0.10)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="faster">
-        <select class="customDo">
-          <option value="faster">Increase speed</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (0.10)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="rewind">
-        <select class="customDo">
-          <option value="rewind">Rewind</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (10)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="advance">
-        <select class="customDo">
-          <option value="advance">Advance</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (10)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="reset">
-        <select class="customDo">
-          <option value="reset">Reset speed</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input
-          class="customValue"
-          type="text"
-          placeholder="value (1.00)"
-          disabled
-        />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
-      <div class="row customs" id="fast">
-        <select class="customDo">
-          <option value="fast">Preferred speed</option>
-        </select>
-        <input
-          class="customKey"
-          type="text"
-          value=""
-          placeholder="press a key"
-        />
-        <input class="customValue" type="text" placeholder="value (1.80)" />
-        <select class="customForce">
-          <option value="false">Do not disable website key bindings</option>
-          <option value="true">Disable website key bindings</option>
-        </select>
-      </div>
+<title>Video Speed Controller: Options</title>
+<link rel="stylesheet" href="options.css" />
+<script src="options.js"></script>
 
-      <button id="add">Add New</button>
-    </section>
+<header>
+  <h1>Video Speed Controller</h1>
+</header>
 
-    <section>
-      <h3>Other</h3>
-      <div class="row">
-        <label for="enabled">Enable</label>
-        <input id="enabled" type="checkbox" />
-      </div>
-      <div class="row">
-        <label for="startHidden">Hide controller by default</label>
-        <input id="startHidden" type="checkbox" />
-      </div>
-      <div class="row">
-        <label for="rememberSpeed">Remember playback speed</label>
-        <input id="rememberSpeed" type="checkbox" />
-      </div>
-      <div class="row">
-        <label for="forceLastSavedSpeed">Force last saved speed<br />
-        <em>Useful for video players that override the speeds set by VideoSpeed</em></label>
-        <input id="forceLastSavedSpeed" type="checkbox" />
-      </div>
-      <div class="row">
-        <label for="audioBoolean">Work on audio</label>
-        <input id="audioBoolean" type="checkbox" />
-      </div>
-      <div class="row">
-        <label for="controllerOpacity">Controller opacity</label>
-        <input id="controllerOpacity" type="text" value="" />
-      </div>
-      <div class="row">
-        <label for="blacklist"
-          >Sites on which extension is disabled<br />
-          (one per line)<br />
-          <br />
-          <em>
-            <a href="https://www.regexpal.com/">Regex</a> is supported.<br />
-            Be sure to use the literal notation.<br />
-            ie: /(.+)youtube\.com(\/*)$/gi
-          </em>
-        </label>
-        <textarea id="blacklist" rows="10" cols="50"></textarea>
-      </div>
-    </section>
+<section id="customs">
+  <h3>Shortcuts</h3>
+  <div class="row customs" id="display">
+    <select class="customDo">
+      <option value="display">Show/hide controller</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (0.10)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="slower">
+    <select class="customDo">
+      <option value="slower">Decrease speed</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (0.10)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="faster">
+    <select class="customDo">
+      <option value="faster">Increase speed</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (0.10)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="rewind">
+    <select class="customDo">
+      <option value="rewind">Rewind</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (10)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="advance">
+    <select class="customDo">
+      <option value="advance">Advance</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (10)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="reset">
+    <select class="customDo">
+      <option value="reset">Reset speed</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input
+      class="customValue"
+      type="text"
+      placeholder="value (1.00)"
+      disabled
+    />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
+  <div class="row customs" id="fast">
+    <select class="customDo">
+      <option value="fast">Preferred speed</option>
+    </select>
+    <input class="customKey" type="text" value="" placeholder="press a key" />
+    <input class="customValue" type="text" placeholder="value (1.80)" />
+    <select class="customForce">
+      <option value="false">Do not disable website key bindings</option>
+      <option value="true">Disable website key bindings</option>
+    </select>
+  </div>
 
-    <button id="save">Save</button>
-    <button id="restore">Restore Defaults</button>
-    <button id="experimental">Show Experimental Features</button>
+  <button id="add">Add New</button>
+</section>
 
-    <div id="status"></div>
+<section>
+  <h3>Other</h3>
+  <div class="row">
+    <label for="enabled">Enable</label>
+    <input id="enabled" type="checkbox" />
+  </div>
+  <div class="row">
+    <label for="startHidden">Hide controller by default</label>
+    <input id="startHidden" type="checkbox" />
+  </div>
+  <div class="row">
+    <label for="rememberSpeed">Remember playback speed</label>
+    <input id="rememberSpeed" type="checkbox" />
+  </div>
+  <div class="row">
+    <label for="forceLastSavedSpeed"
+      >Force last saved speed<br />
+      <em
+        >Useful for video players that override the speeds set by VideoSpeed</em
+      ></label
+    >
+    <input id="forceLastSavedSpeed" type="checkbox" />
+  </div>
+  <div class="row">
+    <label for="audioBoolean">Work on audio</label>
+    <input id="audioBoolean" type="checkbox" />
+  </div>
+  <div class="row">
+    <label for="controllerOpacity">Controller opacity</label>
+    <input id="controllerOpacity" type="text" value="" />
+  </div>
+  <div class="row">
+    <label for="blacklist"
+      >Sites on which extension is disabled<br />
+      (one per line)<br />
+      <br />
+      <em>
+        <a href="https://www.regexpal.com/">Regex</a> is supported.<br />
+        Be sure to use the literal notation.<br />
+        ie: /(.+)youtube\.com(\/*)$/gi
+      </em>
+    </label>
+    <textarea id="blacklist" rows="10" cols="50"></textarea>
+  </div>
+</section>
 
-    <div id="faq">
-      <hr />
+<button id="save">Save</button>
+<button id="restore">Restore Defaults</button>
+<button id="experimental">Show Experimental Features</button>
 
-      <h4>Extension controls not appearing?</h4>
-      <p>
-        This extension is only compatible with HTML5 audio and video. If you
-        don't see the controls showing up, chances are you are viewing a Flash
-        content. If you want to confirm, try right-clicking on the content and
-        inspect the menu: if it mentions flash, then that's the issue. That
-        said, <b>most sites will fallback to HTML5</b> if they detect that Flash
-        is not available. You can try manually disabling Flash plugin in the
-        browser:
-      </p>
+<div id="status"></div>
 
-      <ol>
-        <li>
-          In a new tab, navigate to <code>chrome://settings/content/flash</code>
-        </li>
-        <li>Disable "Allow sites to run Flash"</li>
-        <li>Restart your browser and try playing your audio or video again</li>
-      </ol>
+<div id="faq">
+  <hr />
 
-      <h4>The speed controls are not showing up for local videos?</h4>
-      <p>
-        To enable playback of local media (e.g. File &gt; Open File), you need
-        to grant additional permissions to the extension.
-      </p>
+  <h4>Extension controls not appearing?</h4>
+  <p>
+    This extension is only compatible with HTML5 audio and video. If you don't
+    see the controls showing up, chances are you are viewing a Flash content. If
+    you want to confirm, try right-clicking on the content and inspect the menu:
+    if it mentions flash, then that's the issue. That said,
+    <b>most sites will fallback to HTML5</b> if they detect that Flash is not
+    available. You can try manually disabling Flash plugin in the browser:
+  </p>
 
-      <ol>
-        <li>In a new tab, navigate to <code>chrome://extensions</code></li>
-        <li>
-          Find "Video Speed Controller" extension in the list and enable "Allow
-          access to file URLs"
-        </li>
-        <li>
-          Open a new tab and try opening a local file, the controls should show
-          up
-        </li>
-      </ol>
-    </div>
-  </body>
-</html>
+  <ol>
+    <li>
+      In a new tab, navigate to <code>chrome://settings/content/flash</code>
+    </li>
+    <li>Disable "Allow sites to run Flash"</li>
+    <li>Restart your browser and try playing your audio or video again</li>
+  </ol>
+
+  <h4>The speed controls are not showing up for local videos?</h4>
+  <p>
+    To enable playback of local media (e.g. File &gt; Open File), you need to
+    grant additional permissions to the extension.
+  </p>
+
+  <ol>
+    <li>In a new tab, navigate to <code>chrome://extensions</code></li>
+    <li>
+      Find "Video Speed Controller" extension in the list and enable "Allow
+      access to file URLs"
+    </li>
+    <li>
+      Open a new tab and try opening a local file, the controls should show up
+    </li>
+  </ol>
+</div>

--- a/options.html
+++ b/options.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 
-<title>Video Speed Controller: Options</title>
 <link rel="stylesheet" href="options.css" />
+<meta name="color-scheme" content="light dark">
 <script src="options.js"></script>
+<title>Video Speed Controller: Options</title>
 
 <header>
   <h1>Video Speed Controller</h1>


### PR DESCRIPTION
The settings page has always felt a little outdated to me and everything was a little too small. Once I was looking for a way to enable the extension on local files: it was in the FAQ, but I couldn't find it because my head refused to read the small line which took all the viewport width.
In this redesign I also implemented a dark mode which follows system settings
<img width="1156" alt="Screen Shot 2021-12-06 at 12 13 32" src="https://user-images.githubusercontent.com/50383865/144836610-de4cec2d-3cf8-4141-94c9-b5a36d87501c.png">
<img width="1156" alt="Screen Shot 2021-12-06 at 12 13 44" src="https://user-images.githubusercontent.com/50383865/144836625-74a088fc-c859-4eec-9677-603f0e290f85.png">
<img width="1156" alt="Screen Shot 2021-12-06 at 12 13 55" src="https://user-images.githubusercontent.com/50383865/144836627-62990979-5acb-4d5e-99df-e5d1e293291d.png">
<img width="1156" alt="Screen Shot 2021-12-06 at 12 14 00" src="https://user-images.githubusercontent.com/50383865/144836630-d237e369-8495-46bd-9815-0a86850dcf6c.png">
.
