### PR TITLE
Fix for sling.com and any site that uses document.write

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -653,6 +653,13 @@ function initializeNow(document) {
             case "childList":
               mutation.addedNodes.forEach(function (node) {
                 if (typeof node === "function") return;
+                if (node === document.documentElement) {
+                  // This happens on sites that use document.write, e.g. watch.sling.com
+                  // When the document gets replaced, we lose all event handlers, so we need to reinitialize
+                  log("Document was replaced, reinitializing", 5);
+                  initializeWhenReady(document);
+                  return;
+                }
                 checkForVideo(node, node.parentNode || mutation.target, true);
               });
               mutation.removedNodes.forEach(function (node) {


### PR DESCRIPTION
This extension was broken on sling.com because that site uses document.write, which replaces the document, removing all of our event handlers. The fix is pretty simple since we're already observing mutation events.

You can test it on https://watch.sling.com (no account required).
