### PR TITLE
Add "hellosaurus.com" to exclusion list

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,7 +33,7 @@
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/*",
         "https://meet.google.com/*",
-        "https://hellosaurus.com/*"
+        "https://www.hellosaurus.com/*"
       ],
       "css": ["inject.css"],
       "js": ["inject.js"]

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
       "exclude_matches": [
         "https://plus.google.com/hangouts/*",
         "https://hangouts.google.com/*",
-        "https://meet.google.com/*"
+        "https://meet.google.com/*",
+        "https://hellosaurus.com/*"
       ],
       "css": ["inject.css"],
       "js": ["inject.js"]


### PR DESCRIPTION
Fixes #979.

Added to the exclusion list all links under the "hellosaurus.com" domain as this extension is causing videos to not render when enabled.