### PR TITLE
Fix sling.com (and others) when document.body isn't initialized

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -622,7 +622,7 @@ function initializeNow(document) {
 
   function checkForVideo(node, parent, added) {
     // Only proceed with supposed removal if node is missing from DOM
-    if (!added && document.body.contains(node)) {
+    if (!added && document.body?.contains(node)) {
       return;
     }
     if (


### PR DESCRIPTION
Similar to #977 (again due to document.write), document.body can be null, and when it is, this line was throwing an error, breaking initialization.