### PR TITLE
Fix missing VSC overlay on fullscreen amazon product-page videos

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -351,7 +351,9 @@ function defineVideoController() {
     fragment.appendChild(wrapper);
 
     switch (true) {
-      case location.hostname == "www.amazon.com":
+      // Only special-case Prime Video, not product-page videos (which use
+      // "vjs-tech"), otherwise the overlay disappears in fullscreen mode
+      case location.hostname == "www.amazon.com" && !this.video.classList.contains("vjs-tech"):
       case location.hostname == "www.reddit.com":
       case /hbogo\./.test(location.hostname):
         // insert before parent to bypass overlay


### PR DESCRIPTION
The special case that was added for Amazon Prime Video messes up the overlay in product-page videos in full screen mode.

Example product page: https://www.amazon.com/Sony-WH-1000XM5-Canceling-Headphones-Hands-Free/dp/B09XS7JWHH
