### PR TITLE
fix(popup.js): fix `setIcon` error using `action`

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -40,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
     document.querySelector("#disable").classList.toggle("hide", !enabled);
 
     const suffix = `${enabled ? "" : "_disabled"}.png`;
-    chrome.browserAction.setIcon({
+    chrome.action.setIcon({
       path: {
         "19": "icons/icon19" + suffix,
         "38": "icons/icon38" + suffix,


### PR DESCRIPTION
Manifest V3 uses `action` instead of `browserAction`. 

Reference: https://developer.chrome.com/docs/extensions/reference/api/action#method-setIcon