### PR TITLE
feat: add volume control (#742)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -830,6 +830,10 @@ function runAction(action, value, e) {
         pause(v);
       } else if (action === "muted") {
         muted(v);
+      } else if (action === "louder") {
+        volumeUp(v, value);
+      } else if (action === "softer") {
+        volumeDown(v, value);
       } else if (action === "mark") {
         setMark(v);
       } else if (action === "jump") {
@@ -873,6 +877,14 @@ function resetSpeed(v, target) {
 
 function muted(v) {
   v.muted = v.muted !== true;
+}
+
+function volumeUp(v, value) {
+  v.volume = Math.min(1, (v.volume + value).toFixed(2));
+}
+
+function volumeDown(v, value) {
+  v.volume = Math.max(0, (v.volume - value).toFixed(2));
 }
 
 function setMark(v) {

--- a/options.js
+++ b/options.js
@@ -138,6 +138,8 @@ function add_shortcut() {
     <option value="reset">Reset speed</option>
     <option value="fast">Preferred speed</option>
     <option value="muted">Mute</option>
+    <option value="softer">Decrease volume</option>
+    <option value="louder">Increase volume</option>
     <option value="pause">Pause</option>
     <option value="mark">Set marker</option>
     <option value="jump">Jump to marker</option>


### PR DESCRIPTION
Add volume control, able to add shortcut to increase or decrease the volume (optional, not in default).

See issue: https://github.com/igrigorik/videospeed/issues/742