### PR TITLE
Fixes #1082: Fix for settings not working on Arc Browser 

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,6 @@
 document.addEventListener("DOMContentLoaded", function () {
   document.querySelector("#config").addEventListener("click", function () {
-    window.open(chrome.runtime.getURL("options.html"));
+    chrome.runtime.openOptionsPage()
   });
 
   document.querySelector("#about").addEventListener("click", function () {


### PR DESCRIPTION
Uses `chrome.runtime.openOptionsPage()` instead of `window.open(chrome.runtime.getURL("options.html"));`