### PR TITLE
Fix #1170: Set Draggable Property of HTML5 Video Containers to False

### DIFF
--- a/scriptforsite/youtube.js
+++ b/scriptforsite/youtube.js
@@ -1,0 +1,8 @@
+document.addEventListener('yt-navigate-finish', function(event) {
+    if (!location.pathname.includes('/watch')) { return; };
+    
+    const videoPlayerContainer = document.querySelector(".html5-video-container");
+    if (videoPlayerContainer) {
+        videoPlayerContainer.setAttribute('draggable', false);
+    }
+}, false);


### PR DESCRIPTION
Resets the draggable property of the HTML5 Video containers on YouTube to false (on navigating to a YouTube video). Enables users to move the speed controller easily.