### PR TITLE
Add dynamic speed control feature (#548)

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -112,7 +112,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
     }); // default: G
     tc.settings.keyBindings.push({
       action: "activateGradual",
-      key: Number(storage.gradualKeyCode) || 49,
+      key: Number(storage.gradualKeyCode) || 73,
       value: 0,
       force: false,
       predefined: true
@@ -278,7 +278,7 @@ function defineVideoController() {
       attributeFilter: ["src", "currentSrc"]
     });
 
-    if (ts.settings.gradualSpeedChange) {
+    if (tc.settings.gradualSpeedChange) {
       const speedUp = setInterval(() => {
         // Check if the video is not paused
         if (target.paused) {
@@ -286,20 +286,20 @@ function defineVideoController() {
         }
 
         // Gradually Increment the speed
-        log(`Graddually Increase speed by ${ts.settings.gradualSpeedChangeAmount}`, 5);
+        log(`Graddually Increase speed by ${tc.settings.gradualSpeedChangeAmount}`, 5);
 
         // Increment the speed by the desired amount
         var s = Math.min(
-          target.playbackRate + ts.settings.gradualSpeedChangeAmount,
-          ts.settings.maxSpeed
+          target.playbackRate + tc.settings.gradualSpeedChangeAmount,
+          tc.settings.maxSpeed
         );
         setSpeed(target, s);
 
         // Check if the desired speed is reached
-        if (s >= ts.settings.maxSpeed) {
+        if (s >= tc.settings.maxSpeed) {
           clearInterval(speedUp);
         }
-      }, ts.settings.gradualSpeedChangeDelay);
+      }, tc.settings.gradualSpeedChangeDelay);
     }
   };
 
@@ -897,8 +897,8 @@ function runAction(action, value, e) {
         jumpToMark(v);
       } else if (action === "activateGradual") {
         log("Gradual speed change activated", 4);
-        ts.settings.gradualSpeedChange = !ts.settings.gradualSpeedChange;
-        chrome.storage.sync.set({ gradualSpeedChange: ts.settings.gradualSpeedChange });
+        tc.settings.gradualSpeedChange = !tc.settings.gradualSpeedChange;
+        chrome.storage.sync.set({ gradualSpeedChange: tc.settings.gradualSpeedChange });
       }
     }
   });

--- a/options.html
+++ b/options.html
@@ -129,7 +129,27 @@
           <option value="true">Disable website key bindings</option>
         </select>
       </div>
-
+      <div class="row customs" id="activateGradual">
+        <select class="customDo">
+          <option value="activateGradual">Toggle Gradual Speed Increase</option>
+        </select>
+        <input
+          class="customKey"
+          type="text"
+          value="I"
+          placeholder="press a key"
+        />
+        <input
+          class="customValue"
+          type="text"
+          placeholder=""
+          disabled
+        />
+        <select class="customForce">
+          <option value="false">Do not disable website key bindings</option>
+          <option value="true">Disable website key bindings</option>
+        </select>
+      </div>
       <button id="add">Add New</button>
     </section>
 
@@ -172,6 +192,18 @@
           </em>
         </label>
         <textarea id="blacklist" rows="10" cols="50"></textarea>
+      </div>
+      <div class="row">
+        <label for="gradualSpeedChange">Enable Gradual Speed Increase</label>
+        <input id="gradualSpeedChange" type="checkbox" />
+      </div>
+      <div class="row">
+        <label for="gradualSpeedChangeDelay">Gradual Speed Change Delay (ms)</label>
+        <input id="gradualSpeedChangeDelay" type="number" min="0" step="1000" value="10000" />
+      </div>
+      <div class="row">
+        <label for="gradualSpeedChangeAmount">Gradual Speed Change Amount</label>
+        <input id="gradualSpeedChangeAmount" type="number" min="-1" max="1" step="0.001" value="0.002" />
       </div>
     </section>
 

--- a/options.js
+++ b/options.js
@@ -9,6 +9,9 @@ var tcDefaults = {
   forceLastSavedSpeed: false, //default: false
   enabled: true, // default enabled
   controllerOpacity: 0.3, // default: 0.3
+  gradualSpeedChange: false, // default: false
+  gradualSpeedChangeDelay: 10000, // default: 10000
+  gradualSpeedChangeAmount: 0.002, // default: 0.002
   keyBindings: [
     { action: "display", key: 86, value: 0, force: false, predefined: true }, // V
     { action: "slower", key: 83, value: 0.1, force: false, predefined: true }, // S
@@ -16,7 +19,8 @@ var tcDefaults = {
     { action: "rewind", key: 90, value: 10, force: false, predefined: true }, // Z
     { action: "advance", key: 88, value: 10, force: false, predefined: true }, // X
     { action: "reset", key: 82, value: 1, force: false, predefined: true }, // R
-    { action: "fast", key: 71, value: 1.8, force: false, predefined: true } // G
+    { action: "fast", key: 71, value: 1.8, force: false, predefined: true }, // G
+    { action: "activateGradual", key: 49, value: 0.002, force: false, predefined: true } // I
   ],
   blacklist: `www.instagram.com
     twitter.com
@@ -226,6 +230,9 @@ function save_options() {
   var startHidden = document.getElementById("startHidden").checked;
   var controllerOpacity = document.getElementById("controllerOpacity").value;
   var blacklist = document.getElementById("blacklist").value;
+  var gradualSpeedChange = document.getElementById("gradualSpeedChange").checked;
+  var gradualSpeedChangeDelay = document.getElementById("gradualSpeedChangeDelay").value;
+  var gradualSpeedChangeAmount = document.getElementById("gradualSpeedChangeAmount").value;
 
   chrome.storage.sync.remove([
     "resetSpeed",
@@ -234,6 +241,7 @@ function save_options() {
     "rewindTime",
     "advanceTime",
     "resetKeyCode",
+    "gradualKeyCode",
     "slowerKeyCode",
     "fasterKeyCode",
     "rewindKeyCode",
@@ -248,6 +256,9 @@ function save_options() {
       enabled: enabled,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
+      gradualSpeedChange: gradualSpeedChange,
+      gradualSpeedChangeDelay: gradualSpeedChangeDelay,
+      gradualSpeedChangeAmount: gradualSpeedChangeAmount,
       keyBindings: keyBindings,
       blacklist: blacklist.replace(regStrip, "")
     },
@@ -273,6 +284,9 @@ function restore_options() {
     document.getElementById("controllerOpacity").value =
       storage.controllerOpacity;
     document.getElementById("blacklist").value = storage.blacklist;
+    document.getElementById("gradualSpeedChange").checked = storage.gradualSpeedChange;
+    document.getElementById("gradualSpeedChangeDelay").value = storage.gradualSpeedChangeDelay;
+    document.getElementById("gradualSpeedChangeAmount").value = storage.gradualSpeedChangeAmount;
 
     // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding
     if (storage.keyBindings.filter((x) => x.action == "display").length == 0) {

--- a/options.js
+++ b/options.js
@@ -20,7 +20,7 @@ var tcDefaults = {
     { action: "advance", key: 88, value: 10, force: false, predefined: true }, // X
     { action: "reset", key: 82, value: 1, force: false, predefined: true }, // R
     { action: "fast", key: 71, value: 1.8, force: false, predefined: true }, // G
-    { action: "activateGradual", key: 49, value: 0.002, force: false, predefined: true } // I
+    { action: "activateGradual", key: 73, value: 0.002, force: false, predefined: true } // I
   ],
   blacklist: `www.instagram.com
     twitter.com


### PR DESCRIPTION
This pull request implements the **Automated Dynamic Speed Control** feature as discussed in [Issue #548] The feature allows users to set a dynamic playback speed that adjusts the video speed over time. This feature might be helpful for people who wish to enhance their audio comprehension speed in an "unnoticeable" automatic manner.

Users can set up a gradual increase activation key, speed increase delay (in ms) and speed change amount in the settings.

At testing everything seems to work as expected.
