### PR TITLE
Fix YouTube subtitles lagging behind

### DIFF
--- a/inject_youtube.js
+++ b/inject_youtube.js
@@ -1,0 +1,9 @@
+(() => {
+    const oldSetTimeout = window.setTimeout;
+    window.setTimeout = (f, delay = 0, ...args) => {
+        // Make YouTube update captions 4x as frequent so it can
+        // keep up with Video Speed Controller
+        delay /= 4;
+        return oldSetTimeout(f, delay, ...args);
+    };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,11 @@
       ],
       "css": ["inject.css"],
       "js": ["inject.js"]
+    },
+    {
+      "matches": ["https://www.youtube.com/*"],
+      "js": ["inject_youtube.js"],
+      "world": "MAIN"
     }
   ],
   "web_accessible_resources": [{


### PR DESCRIPTION
With this, subtitles on YouTube should keep up with up to 8x speed. They should no longer lag behind nor alternate between suddenly slowing down and speeding up.

This works by making YouTube's timers fire earlier / more frequently. This makes YouTube pick up the earlier-than-usual video positions caused by Video Speed Controller, and both refresh earlier and schedule the next timer to refresh earlier. A constant 4x boost is used for simplicity (the new script runs elsewhere in the unisolated MAIN world, so getting settings is hard), and 4x should be enough for most people.

YouTube's own speed should not be set to 0.25, or we get the same behavior as before this PR. The constant 4x should be low enough not to cause lag even with timers firing at 8x the normal 1x speed when YouTube's speed is set to 2x.

A funny side effect of this is that ads are cut a few seconds short.

Fixes #537