### PR TITLE
Fix: Prevent blackout on Amazon Prime Video caused by fullscreen overlay

### DIFF
--- a/inject.css
+++ b/inject.css
@@ -96,3 +96,8 @@ div.legacy-video-player.has_played.vertically_center:before {
 .Shared-Video-player > .vsc-controller {
   height: 0;
 }
+
+/* Fix black overlay on Amazon Prime Video */
+.dv-player-fullscreen .vsc-controller {
+  height: 0;
+}


### PR DESCRIPTION
## Summary

This pull request fixes an issue where Amazon Prime Video's playback screen appears completely black when using the Video Speed Controller extension.

## What was changed

- Amazon Prime Video sets the `.vsc-controller` element's `height` to `100%`, which causes it to cover the entire screen.  
To fix this, I added a CSS rule to set its height to `0` when inside `.dv-player-fullscreen`.
  
- Verified to work on Prime Video as of May 10, 2025.

Closes #1186
