### PR TITLE
add option to edit button size for better support of touchscreen.

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -321,6 +321,7 @@ function defineVideoController() {
       (e) => {
         runAction(e.target.dataset["action"], false, e);
         e.stopPropagation();
+        e.preventDefault();
       },
       true
     );

--- a/inject.js
+++ b/inject.js
@@ -13,6 +13,7 @@ var tc = {
     audioBoolean: false, // default: false
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
+    controllerButtonSize: 14,
     keyBindings: [],
     blacklist: `\
       www.instagram.com
@@ -117,6 +118,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
       startHidden: tc.settings.startHidden,
       enabled: tc.settings.enabled,
       controllerOpacity: tc.settings.controllerOpacity,
+      controllerButtonSize: tc.settings.controllerButtonSize,
       blacklist: tc.settings.blacklist.replace(regStrip, "")
     });
   }
@@ -128,6 +130,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
   tc.settings.enabled = Boolean(storage.enabled);
   tc.settings.startHidden = Boolean(storage.startHidden);
   tc.settings.controllerOpacity = Number(storage.controllerOpacity);
+  tc.settings.controllerButtonSize = Number(storage.controllerButtonSize);
   tc.settings.blacklist = String(storage.blacklist);
 
   // ensure that there is a "display" binding (for upgrades from versions that had it as a separate binding)
@@ -301,11 +304,9 @@ function defineVideoController() {
           @import "${chrome.runtime.getURL("shadow.css")}";
         </style>
 
-        <div id="controller" style="top:${top}; left:${left}; opacity:${
-      tc.settings.controllerOpacity
-    }">
-          <span data-action="drag" class="draggable">${speed}</span>
-          <span id="controls">
+        <div id="controller" style="top:${top}; left:${left}; opacity:${tc.settings.controllerOpacity};">
+          <span data-action="drag" class="draggable" style="font-size: ${tc.settings.controllerButtonSize}px; line-height: ${tc.settings.controllerButtonSize}px;">${speed}</span>
+          <span id="controls" style="font-size: ${tc.settings.controllerButtonSize}px; line-height: ${tc.settings.controllerButtonSize}px;">
             <button data-action="rewind" class="rw">«</button>
             <button data-action="slower">&minus;</button>
             <button data-action="faster">&plus;</button>
@@ -333,6 +334,13 @@ function defineVideoController() {
             getKeyBindings(e.target.dataset["action"]),
             e
           );
+          e.stopPropagation();
+        },
+        true
+      );
+      button.addEventListener(
+        "touchstart",
+        (e) => {
           e.stopPropagation();
         },
         true

--- a/options.html
+++ b/options.html
@@ -161,6 +161,10 @@
         <input id="controllerOpacity" type="text" value="" />
       </div>
       <div class="row">
+        <label for="controllerButtonSize">Controller Button Size</label>
+        <input id="controllerButtonSize" type="text" value="" />
+      </div>
+      <div class="row">
         <label for="blacklist"
           >Sites on which extension is disabled<br />
           (one per line)<br />

--- a/options.js
+++ b/options.js
@@ -9,6 +9,7 @@ var tcDefaults = {
   forceLastSavedSpeed: false, //default: false
   enabled: true, // default enabled
   controllerOpacity: 0.3, // default: 0.3
+  controllerButtonSize: 14, // default: 14
   keyBindings: [
     { action: "display", key: 86, value: 0, force: false, predefined: true }, // V
     { action: "slower", key: 83, value: 0.1, force: false, predefined: true }, // S
@@ -225,6 +226,7 @@ function save_options() {
   var enabled = document.getElementById("enabled").checked;
   var startHidden = document.getElementById("startHidden").checked;
   var controllerOpacity = document.getElementById("controllerOpacity").value;
+  var controllerButtonSize = document.getElementById("controllerButtonSize").value;
   var blacklist = document.getElementById("blacklist").value;
 
   chrome.storage.sync.remove([
@@ -248,6 +250,7 @@ function save_options() {
       enabled: enabled,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
+      controllerButtonSize: controllerButtonSize,
       keyBindings: keyBindings,
       blacklist: blacklist.replace(regStrip, "")
     },
@@ -270,8 +273,8 @@ function restore_options() {
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("enabled").checked = storage.enabled;
     document.getElementById("startHidden").checked = storage.startHidden;
-    document.getElementById("controllerOpacity").value =
-      storage.controllerOpacity;
+    document.getElementById("controllerOpacity").value = storage.controllerOpacity;
+    document.getElementById("controllerButtonSize").value = storage.controllerButtonSize;
     document.getElementById("blacklist").value = storage.blacklist;
 
     // ensure that there is a "display" binding for upgrades from versions that had it as a separate binding

--- a/shadow.css
+++ b/shadow.css
@@ -61,8 +61,8 @@ button {
   font-weight: normal;
   border-radius: 5px;
   padding: 1px 5px 3px 5px;
-  font-size: 14px;
-  line-height: 14px;
+  font-size: inherit;
+  line-height: inherit;
   border: 0px solid white;
   font-family: "Lucida Console", Monaco, monospace;
   margin: 0px 2px 2px 2px;


### PR DESCRIPTION
I added a new option to configure the "controller size" as the button were way too small to be used with a smartphone or tablet.

I also made it so the buttons catch the touchstart event as without that a double tap on a button would be caught by the video and rewind the video (on youtube).

I did consider adding support for tactile controller repositioning, but while it did work, I didn't manage to override the default touchmove behavior (that on youtube enables to switch to picture on picture mode) so I gave up for that feature that was not very useful anyway.