### PR TITLE
Fix #1196: Make add-on overwrite site shortcut by default

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -68,42 +68,42 @@ chrome.storage.sync.get(tc.settings, function (storage) {
       action: "slower",
       key: Number(storage.slowerKeyCode) || 83,
       value: Number(storage.speedStep) || 0.1,
-      force: false,
+      force: true,
       predefined: true
     }); // default S
     tc.settings.keyBindings.push({
       action: "faster",
       key: Number(storage.fasterKeyCode) || 68,
       value: Number(storage.speedStep) || 0.1,
-      force: false,
+      force: true,
       predefined: true
     }); // default: D
     tc.settings.keyBindings.push({
       action: "rewind",
       key: Number(storage.rewindKeyCode) || 90,
       value: Number(storage.rewindTime) || 10,
-      force: false,
+      force: true,
       predefined: true
     }); // default: Z
     tc.settings.keyBindings.push({
       action: "advance",
       key: Number(storage.advanceKeyCode) || 88,
       value: Number(storage.advanceTime) || 10,
-      force: false,
+      force: true,
       predefined: true
     }); // default: X
     tc.settings.keyBindings.push({
       action: "reset",
       key: Number(storage.resetKeyCode) || 82,
       value: 1.0,
-      force: false,
+      force: true,
       predefined: true
     }); // default: R
     tc.settings.keyBindings.push({
       action: "fast",
       key: Number(storage.fastKeyCode) || 71,
       value: Number(storage.fastSpeed) || 1.8,
-      force: false,
+      force: true,
       predefined: true
     }); // default: G
     tc.settings.version = "0.5.3";
@@ -141,7 +141,7 @@ chrome.storage.sync.get(tc.settings, function (storage) {
       action: "display",
       key: Number(storage.displayKeyCode) || 86,
       value: 0,
-      force: false,
+      force: true,
       predefined: true
     }); // default V
   }
@@ -645,7 +645,7 @@ function initializeNow(document) {
         var item = tc.settings.keyBindings.find((item) => item.key === keyCode);
         if (item) {
           runAction(item.action, item.value);
-          if (item.force === "true") {
+          if (item.force) {
             // disable websites key bindings
             event.preventDefault();
             event.stopPropagation();

--- a/options.html
+++ b/options.html
@@ -21,8 +21,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (0.10)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="slower">
@@ -32,8 +32,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (0.10)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="faster">
@@ -43,8 +43,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (0.10)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="rewind">
@@ -54,8 +54,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (10)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="advance">
@@ -65,8 +65,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (10)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="reset">
@@ -76,8 +76,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (1.00)" disabled />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
     <div class="row customs" id="fast">
@@ -87,8 +87,8 @@
       <input class="customKey" type="text" value="" placeholder="press a key" />
       <input class="customValue" type="text" placeholder="value (1.80)" />
       <select class="customForce">
-        <option value="false">Do not disable website key bindings</option>
-        <option value="true">Disable website key bindings</option>
+        <option value="true">Override site shortcut</option>
+        <option value="false">Combine with site shortcut</option>
       </select>
     </div>
 

--- a/options.js
+++ b/options.js
@@ -11,13 +11,13 @@ var tcDefaults = {
   controllerOpacity: 0.3, // default: 0.3
   controllerButtonSize: 14, // default: 14
   keyBindings: [
-    { action: "display", key: 86, value: 0, force: false, predefined: true }, // V
-    { action: "slower", key: 83, value: 0.1, force: false, predefined: true }, // S
-    { action: "faster", key: 68, value: 0.1, force: false, predefined: true }, // D
-    { action: "rewind", key: 90, value: 10, force: false, predefined: true }, // Z
-    { action: "advance", key: 88, value: 10, force: false, predefined: true }, // X
-    { action: "reset", key: 82, value: 1, force: false, predefined: true }, // R
-    { action: "fast", key: 71, value: 1.8, force: false, predefined: true } // G
+    { action: "display", key: 86, value: 0, force: true, predefined: true }, // V
+    { action: "slower", key: 83, value: 0.1, force: true, predefined: true }, // S
+    { action: "faster", key: 68, value: 0.1, force: true, predefined: true }, // D
+    { action: "rewind", key: 90, value: 10, force: true, predefined: true }, // Z
+    { action: "advance", key: 88, value: 10, force: true, predefined: true }, // X
+    { action: "reset", key: 82, value: 1, force: true, predefined: true }, // R
+    { action: "fast", key: 71, value: 1.8, force: true, predefined: true } // G
   ],
   blacklist: `www.instagram.com
     twitter.com
@@ -76,6 +76,12 @@ var keyCodeAliases = {
   221: "]",
   222: "'"
 };
+
+
+function parseToBool(stringBool){
+  if (stringBool == "true") return true;
+  return false;
+}
 
 function recordKeyPress(e) {
   if (
@@ -149,8 +155,8 @@ function add_shortcut() {
     <input class="customKey" type="text" placeholder="press a key"/>
     <input class="customValue" type="text" placeholder="value (0.10)"/>
     <select class="customForce">
-    <option value="false">Do not disable website key bindings</option>
-    <option value="true">Disable website key bindings</option>
+    <option value="true">Override site shortcut</option>
+    <option value="false">Combine with site shortcut</option>
     </select>
     <button class="removeParent">X</button>`;
   var div = document.createElement("div");
@@ -167,7 +173,7 @@ function createKeyBindings(item) {
   const action = item.querySelector(".customDo").value;
   const key = item.querySelector(".customKey").keyCode;
   const value = Number(item.querySelector(".customValue").value);
-  const force = item.querySelector(".customForce").value;
+  const force = parseToBool(item.querySelector(".customForce").value);
   const predefined = !!item.id; //item.id ? true : false;
 
   keyBindings.push({
@@ -282,7 +288,7 @@ function restore_options() {
       storage.keyBindings.push({
         action: "display",
         value: 0,
-        force: false,
+        force: true,
         predefined: true
       });
     }


### PR DESCRIPTION
### Issue #1196

I've read the issue linked and for me it made sense.

When you click to "Show Experimental Features", it shows at the side of each shortcut a select element where you can set it to prevent the default behavior for this shortcut on the website to happen.

```html
<option value="false">Do not disable website key bindings</option>
<option value="true">Disable website key bindings</option>
```

The default value is the 'false' option (first option) and it keeps both behavior happening at the same time.

I don't know if the correct behavior should be this. In my opinion, the default should keep only the add-on behavior, but the option to change could still be available.

Additionally, in my opinion, the text of these options is not very clear, as it does not explicitly state the expected behavior of each option.


## Fixes #1196

### What I did
- Set to true the force attribute of the items present in the tc.settings.keyBindings in order to make it overwrites by default the site's default shortcut for all keys set in the extension.
- Changed the text of the selection options to little bit more clear meaning of the expected behavior.
    ```html
    <option value="true">Override site shortcut</option>
    <option value="false">Combine with site shortcut</option>
    ```
- Created a function to convert the string values from the selection options into booleans. Since the values are read as strings from the DOM, this ensures they are consistently treated as boolean values. This allows the conditionals to use if (item.force) directly, instead of comparing to the string "true"

### Notes
Let me know what do you think about take it out of the group of experimental features and everyting about the changes.