### PR TITLE
Replace deprecated social links

### DIFF
--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -22,7 +22,7 @@ var tcDefaults = {
     { action: "jump", key: 74, value: 0, force: false, predefined: true } // J
   ],
   blacklist: `www.instagram.com
-    twitter.com
+    x.com
     imgur.com
     teams.microsoft.com
   `.replace(regStrip, "")

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -38,8 +38,7 @@ const DEFAULT_SETTINGS = {
   keyBindings: [],
   blacklist: `
     www.instagram.com
-    twitter.com
-    vine.co
+    x.com
     imgur.com
     teams.microsoft.com
   `.replace(regStrip, ''),

--- a/tests/fixtures/test-page.html
+++ b/tests/fixtures/test-page.html
@@ -113,7 +113,7 @@
         const { isBlacklisted, inIframe, findMediaElements } = await import('../../src/utils/dom-utils.js');
         
         // Test blacklist functionality
-        const blacklisted = isBlacklisted('www.instagram.com\ntwitter.com');
+        const blacklisted = isBlacklisted('www.instagram.com\nx.com');
         resultsDiv.textContent += `Blacklist test (should be false): ${!blacklisted ? 'PASS' : 'FAIL'}\n`;
         
         // Test iframe detection

--- a/tests/helpers/chrome-mock.js
+++ b/tests/helpers/chrome-mock.js
@@ -12,7 +12,7 @@ const mockStorage = {
   startHidden: false,
   controllerOpacity: 0.3,
   controllerButtonSize: 14,
-  blacklist: 'www.instagram.com\ntwitter.com',
+  blacklist: 'www.instagram.com\nx.com',
   logLevel: 3,
 };
 
@@ -111,7 +111,7 @@ export function resetMockStorage() {
     startHidden: false,
     controllerOpacity: 0.3,
     controllerButtonSize: 14,
-    blacklist: 'www.instagram.com\ntwitter.com',
+    blacklist: 'www.instagram.com\nx.com',
     logLevel: 3,
   });
 }

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -46,7 +46,7 @@ global.chrome = {
           startHidden: false,
           controllerOpacity: 0.3,
           controllerButtonSize: 14,
-          blacklist: "www.instagram.com\ntwitter.com",
+          blacklist: "www.instagram.com\nx.com",
           logLevel: 3
         };
         setTimeout(() => callback(mockData), 10);


### PR DESCRIPTION
This PR updates social media links by:

- Replacing `twitter.com` entries with x.com to reflect Twitter's rebranding.
- Removing `vine.co` link since the service is no longer active.