### PR TITLE
handle video elements that don't have a parentElement

### DIFF
--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -177,7 +177,9 @@ class VideoSpeedExtension {
       const mediaElements = this.mediaObserver.scanAll(document);
 
       mediaElements.forEach((media) => {
-        this.onVideoFound(media, media.parentElement);
+        // media.parentElement almost always works. However, if there's a shadow DOM and the
+        // video is in the root, parentElement is undefined.
+        this.onVideoFound(media, media.parentElement || media.parentNode);
       });
 
       this.logger.info(`Attached controllers to ${mediaElements.length} existing media elements`);


### PR DESCRIPTION
Consider this example HTML:
```
<custom-element>
    #shadow-root (open)
        <video ...>
```
Here, video.parentElement is undefined. This causes an exception in the current codebase.

To prevent the exception, this PR proposes using video.parentElement || video.parentNode instead of just video.parentElement.

Example player: The BBC smp-toucan player currently has the following structure:
```
<smp-toucan-player ...
    #shadow-root (open)
    ...
    <smp-playback>
        #shadow-root (open)
            ...
            <video ...
    ...
```
and video.parentElement is undefined, whereas video.parentNode is #shadow-root (open)

Reference link: https://www.bbc.com/news/uk-england-gloucestershire-68543486