### PR TITLE
when processing shadowRoots, recurse into each shadowRoot

### DIFF
--- a/src/observers/media-observer.js
+++ b/src/observers/media-observer.js
@@ -26,12 +26,22 @@ class MediaElementObserver {
     mediaElements.push(...regularMedia);
 
     // Find media elements in shadow DOMs
-    document.querySelectorAll('*').forEach((element) => {
-      if (element.shadowRoot) {
-        const shadowMedia = element.shadowRoot.querySelectorAll(mediaTagSelector);
-        mediaElements.push(...shadowMedia);
-      }
-    });
+    function findShadowMedia(root, selector) {
+      const results = [];
+      // Add any matching elements in current shadow root
+      results.push(...root.querySelectorAll(selector));
+      // Recursively check all elements with shadow roots
+      root.querySelectorAll('*').forEach(element => {
+        if (element.shadowRoot) {
+          results.push(...findShadowMedia(element.shadowRoot, selector));
+        }
+      });
+      return results;
+    }
+    
+    // In scanForMedia method, replace the existing shadow DOM search with:
+    const shadowMedia = findShadowMedia(document, mediaTagSelector);
+    mediaElements.push(...shadowMedia);
 
     // Find site-specific media elements
     const siteSpecificMedia = this.siteHandler.detectSpecialVideos(document);


### PR DESCRIPTION
Consider this HTML from the BBC smp-toucan player:
```
<smp-toucan-player ...
    #shadow-root (open)
    ...
    <smp-playback>
        #shadow-root (open)
            ...
            <video ...
    ...
```

The current codebase only searches the first level of shadow roots. This PR proposes recursively searching shadowRoots, which will allow the extension to work on the BBC sites.

Reference link: https://www.bbc.com/news/uk-england-gloucestershire-68543486