### PR TITLE
Chore/add badge at readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ local
 dist
 tests/e2e/screenshots
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # The science of accelerated playback
 
+| Chrome Extension                                                       | Downloads                                                                        | GitHub Release                                                 |
+|------------------------------------------------------------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------|
+| [![Chrome Web Store][chrome-web-store-version]][chrome-web-store-link] | [![Chrome Web Store Users][chrome-web-store-users-badge]][chrome-web-store-link] | [![GitHub release][github-release-badge]][github-release-link] |
+
+<!-- Badges -->
+[chrome-web-store-version]: https://img.shields.io/chrome-web-store/v/nffaoalbilbmmfgbnbgppjihopabppdk?label=Chrome%20Web%20Store
+[chrome-web-store-users-badge]: https://img.shields.io/chrome-web-store/users/nffaoalbilbmmfgbnbgppjihopabppdk
+[github-release-badge]: https://img.shields.io/github/v/release/igrigorik/videospeed
+
+<!-- Links -->
+[chrome-web-store-link]: https://chrome.google.com/webstore/detail/poe2-trade-butler/nffaoalbilbmmfgbnbgppjihopabppdk
+[github-release-link]: https://github.com/igrigorik/videospeed/releases
+
 **TL;DR: faster playback translates to better engagement and retention.**
 
 The average adult reads prose text at


### PR DESCRIPTION
This PR updates the README to include badges for the Chrome Web Store version, total downloads, and the latest GitHub release.  
These badges help provide quick reference to the current extension version, user count, and release status directly from the project page.

<img width="913" height="501" alt="image" src="https://github.com/user-attachments/assets/3f3826c6-a061-41a2-afef-de87ba446e24" />