### PR TITLE
Add the reset button to quick shortcuts

### DIFF
--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -150,6 +150,7 @@ class ShadowDOMManager {
       { action: 'slower', text: '−', class: '' },
       { action: 'faster', text: '+', class: '' },
       { action: 'advance', text: '»', class: 'rw' },
+      { action: 'reset', text: '↺', class: '' },
       { action: 'display', text: '×', class: 'hideButton' },
     ];
 


### PR DESCRIPTION
This PR adds a button that resets the video playback speed to the speed 1x. On desktop, users can do this using a keyboard shortcut, but mobile and tablet users don’t have access to that option. This button ensures the same functionality is available across all devices.

**Before:**
<img width="206" height="49" alt="before" src="https://github.com/user-attachments/assets/07c452ba-1340-4e3b-8ec8-10b2f14c0cee" />

**After:**
<img width="225" height="51" alt="after" src="https://github.com/user-attachments/assets/68c90960-acdb-4dd7-a44d-9a82ec5b7cbc" />