### PR TITLE
Adds an option to place the controls at different corners of the video frame

### DIFF
--- a/CONTROLLER_POSITION_FEATURE.md
+++ b/CONTROLLER_POSITION_FEATURE.md
@@ -1,0 +1,96 @@
+# Controller Position Feature
+
+## Overview
+
+The Video Speed Controller now supports customizable positioning of the controller overlay. Users can choose from four different positions:
+
+- **Top Left** (default) - Controller appears at the top-left corner of videos
+- **Top Right** - Controller appears at the top-right corner of videos  
+- **Bottom Left** - Controller appears at the bottom-left corner of videos
+- **Bottom Right** - Controller appears at the bottom-right corner of videos
+
+## How to Use
+
+1. **Open Extension Settings**: Click on the extension icon and select "Options" or navigate to `chrome://extensions` and click "Details" → "Extension options"
+
+2. **Find Position Setting**: The controller position setting is now visible in the main "Other" section (no need to enable advanced features)
+
+3. **Select Position**: Choose your preferred position from the dropdown menu:
+   - Top Left (default)
+   - Top Right  
+   - Bottom Left
+   - Bottom Right
+
+4. **Save Settings**: Click "Save" to apply your changes
+
+5. **Refresh Pages**: **IMPORTANT** - You must refresh any open video pages to see the new controller position take effect
+
+## Troubleshooting
+
+### "Settings show Top Left but I selected something else"
+
+This can happen if:
+
+1. **You haven't refreshed the video page** - After changing the position setting, you must refresh any open video pages
+2. **The settings weren't saved** - Check the browser console for any error messages
+3. **Cache issues** - Try clearing your browser cache or opening an incognito window
+
+### "Controller position setting is not visible"
+
+The controller position dropdown should be visible in the main "Other" section of the options page. If it's not visible:
+
+1. Make sure you have the latest version of the extension
+2. Try refreshing the options page
+3. Check if there are any console errors
+
+### Debug Information
+
+To debug issues:
+
+1. Open the browser console (F12 → Console tab)
+2. Look for error messages when:
+   - Opening the options page
+   - Saving settings
+   - Loading video pages
+
+Look for error messages if the feature isn't working as expected. The extension logs important events at the INFO level and errors at the ERROR level.
+
+## Technical Implementation
+
+### Files Modified
+
+- `src/utils/constants.js` - Added `CONTROLLER_POSITIONS` constant and `controllerPosition` default setting
+- `src/core/settings.js` - Added handling for the `controllerPosition` setting
+- `src/ui/shadow-dom.js` - Updated `calculatePosition()` method and `createShadowDOM()` to support positioning
+- `src/core/video-controller.js` - Updated `initializeControls()` to use position setting
+- `src/ui/options/options.html` - Added position dropdown to options page
+- `src/ui/options/options.js` - Added save/restore logic for position setting
+- `src/ui/drag-handler.js` - Updated drag handling to work with positioned controllers
+- `src/styles/inject.css` - Added position-specific CSS classes
+
+### Position Calculation
+
+The controller position is calculated based on:
+- Video element's bounding rectangle
+- User's position preference (top/bottom + left/right)
+- Estimated controller dimensions (50px height, 200px width)
+
+### CSS Classes
+
+Position-specific CSS classes are applied to the controller wrapper:
+- `.vsc-position-top-left`
+- `.vsc-position-top-right` 
+- `.vsc-position-bottom-left`
+- `.vsc-position-bottom-right`
+
+These classes set appropriate `transform-origin` values for better visual behavior.
+
+## Backward Compatibility
+
+- Default position remains "top-left" 
+- Existing installations will continue to work without changes
+- The setting is stored in Chrome sync storage like other extension settings
+
+## Testing
+
+A test file `test-position.html` is included to verify the positioning logic works correctly across different scenarios.

--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -388,7 +388,37 @@ window.addEventListener('VSC_MESSAGE', (event) => {
           extension.actionHandler.runAction('display', null, null);
         }
         break;
+
+      case 'VSC_SETTINGS_UPDATED':
+        // Handle settings update from options page
+        window.VSC.logger.info('Settings updated, reloading configuration...');
+        if (extension.config) {
+          extension.config.load().then(() => {
+            window.VSC.logger.info('Configuration reloaded with new settings');
+            
+            // If controller position changed, we need to recreate controllers
+            if (message.payload && message.payload.controllerPosition) {
+              window.VSC.logger.info(`Controller position changed to: ${message.payload.controllerPosition}`);
+              // Note: Controllers will be recreated on next video load/page refresh
+            }
+          }).catch((error) => {
+            window.VSC.logger.error('Failed to reload settings:', error);
+          });
+        }
+        break;
     }
+  }
+});
+
+// Listen for settings changes from injected context (when content script updates storage)
+window.addEventListener('VSC_USER_SETTINGS', (event) => {
+  window.VSC.logger.debug('Received updated user settings');
+  if (extension.config) {
+    extension.config.load().then(() => {
+      window.VSC.logger.debug('Configuration updated from user settings event');
+    }).catch((error) => {
+      window.VSC.logger.error('Failed to update configuration from user settings:', error);
+    });
   }
 });
 

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -57,12 +57,17 @@ class VideoController {
   initializeSpeed() {
     const targetSpeed = this.getTargetSpeed();
 
-    window.VSC.logger.debug(`Setting initial playbackRate to: ${targetSpeed}`);
+    window.VSC.logger.debug(`Setting initial playbackRate to: ${targetSpeed} (current: ${this.video.playbackRate})`);
 
-    // Use adjustSpeed for initial speed setting to ensure consistency
-    if (this.actionHandler && targetSpeed !== this.video.playbackRate) {
+    // Always set speed if we have an action handler, regardless of current playback rate
+    // This ensures the speed is properly initialized and the UI stays in sync
+    if (this.actionHandler) {
       window.VSC.logger.debug('Setting initial speed via adjustSpeed');
       this.actionHandler.adjustSpeed(this.video, targetSpeed, { source: 'internal' });
+    } else {
+      // Fallback: set playback rate directly if no action handler
+      window.VSC.logger.debug('No action handler, setting playbackRate directly');
+      this.video.playbackRate = targetSpeed;
     }
   }
 
@@ -99,13 +104,16 @@ class VideoController {
     window.VSC.logger.debug('initializeControls Begin');
 
     const document = this.video.ownerDocument;
-    const speed = window.VSC.Constants.formatSpeed(this.video.playbackRate);
+    
+    // Use the target speed for UI initialization, not current playback rate
+    const targetSpeed = this.getTargetSpeed();
+    const speed = window.VSC.Constants.formatSpeed(targetSpeed);
     
     // Get position based on user preference
     const userPosition = this.config.settings.controllerPosition || 'top-left';
     const position = window.VSC.ShadowDOMManager.calculatePosition(this.video, userPosition);
 
-    window.VSC.logger.debug(`Speed variable set to: ${speed}`);
+    window.VSC.logger.debug(`Speed variable set to: ${speed} (target: ${targetSpeed}, current: ${this.video.playbackRate})`);
 
     // Create wrapper element
     const wrapper = document.createElement('div');

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -70,7 +70,7 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
    * @returns {Array<string>} CSS selectors
    */
   getVideoContainerSelectors() {
-    return ['.html5-video-player', '#movie_player', '.ytp-player-content'];
+    return ['.html5-video-player', '#movie_player', '.ytp-player-content.ytp-iv-player-content', '.ytp-player-content'];
   }
 
   /**

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -24,6 +24,23 @@
   user-select: none;
 }
 
+/* Position-specific styles */
+.vsc-position-top-left {
+  transform-origin: top left !important;
+}
+
+.vsc-position-top-right {
+  transform-origin: top right !important;
+}
+
+.vsc-position-bottom-left {
+  transform-origin: bottom left !important;
+}
+
+.vsc-position-bottom-right {
+  transform-origin: bottom right !important;
+}
+
 /* Origin specific overrides */
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -66,6 +66,18 @@
   top: 60px;
 }
 
+/* YouTube bottom-positioned controllers - avoid overlapping with native controls */
+.html5-video-player .vsc-position-bottom-left,
+.html5-video-player .vsc-position-bottom-right {
+  transform: translateY(10px);
+}
+
+/* When YouTube controls are hidden, reduce the offset */
+.ytp-autohide .vsc-position-bottom-left,
+.ytp-autohide .vsc-position-bottom-right {
+  transform: translateY(-10px); /* Reduced from -20px */
+}
+
 /* Facebook player */
 #facebook .vsc-controller {
   position: relative;

--- a/src/ui/drag-handler.js
+++ b/src/ui/drag-handler.js
@@ -23,17 +23,20 @@ class DragHandler {
 
     const initialMouseXY = [e.clientX, e.clientY];
     const initialControllerXY = [
-      parseInt(shadowController.style.left) || 0,
-      parseInt(shadowController.style.top) || 0,
+      parseInt(shadowController.style.left) || parseInt(controller.style.left) || 0,
+      parseInt(shadowController.style.top) || parseInt(controller.style.top) || 0,
     ];
 
     const startDragging = (e) => {
-      const style = shadowController.style;
       const dx = e.clientX - initialMouseXY[0];
       const dy = e.clientY - initialMouseXY[1];
 
-      style.left = `${initialControllerXY[0] + dx}px`;
-      style.top = `${initialControllerXY[1] + dy}px`;
+      // Update both shadow controller and wrapper positions
+      controller.style.left = `${initialControllerXY[0] + dx}px`;
+      controller.style.top = `${initialControllerXY[1] + dy}px`;
+      
+      shadowController.style.left = '0px';
+      shadowController.style.top = '0px';
     };
 
     const stopDragging = () => {

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -104,6 +104,16 @@
         <em>Prevent video players that override VSC speed</em></label>
       <input id="forceLastSavedSpeed" type="checkbox" />
     </div>
+    <div class="row">
+      <label for="controllerPosition">Controller position<br />
+        <em>Where the controller appears on videos</em></label>
+      <select id="controllerPosition">
+        <option value="top-left">Top Left</option>
+        <option value="top-right">Top Right</option>
+        <option value="bottom-left">Bottom Left</option>
+        <option value="bottom-right">Bottom Right</option>
+      </select>
+    </div>
     <div class="row advanced-feature">
       <label for="controllerOpacity">Controller opacity</label>
       <input id="controllerOpacity" type="text" value="" />

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -264,9 +264,24 @@ class ShadowDOMManager {
       top = `${Math.max(rect.top - (offsetRect?.top || 0), 0)}px`;
     } else {
       // Bottom positions - need to account for controller height and video controls
-      // Leave extra space (80px) to avoid overlapping with video's native controls
-      const bottomOffset = rect.bottom - (offsetRect?.top || 0) - 80; // Increased from 50px to 80px
-      top = `${Math.max(bottomOffset, 0)}px`;
+      let bottomOffset = 80; // Default offset
+      
+      // YouTube-specific bottom positioning to avoid native controls
+      if (location.hostname === 'www.youtube.com') {
+        // YouTube's control bar is typically around 40-50px, but we need extra space
+        // for our controller height (~30px) plus some margin
+        bottomOffset = 120; // Increased offset for YouTube
+        
+        // Try to detect if YouTube controls are visible and adjust accordingly
+        const ytpControls = document.querySelector('.ytp-chrome-bottom');
+        if (ytpControls) {
+          const controlsHeight = ytpControls.offsetHeight || 40;
+          bottomOffset = Math.max(bottomOffset, controlsHeight + 50); // Controls height + controller + margin
+        }
+      }
+      
+      const calculatedBottom = rect.bottom - (offsetRect?.top || 0) - bottomOffset;
+      top = `${Math.max(calculatedBottom, 0)}px`;
     }
     
     if (positionConfig.left) {

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -163,10 +163,7 @@ class ShadowDOMManager {
     draggable.style.cssText = `font-size: ${buttonSize}px;`;
     draggable.textContent = speed;
 
-    // For right positions, mirror the layout: controls appear to the left of speed indicator
-    // For left positions, keep original: speed indicator first, then controls
     if (positionConfig.left) {
-      // Left positions: speed indicator + controls (original behavior)
       controller.appendChild(draggable);
       
       buttons.forEach((btnConfig) => {
@@ -181,10 +178,6 @@ class ShadowDOMManager {
       
       controller.appendChild(controls);
     } else {
-      // Right positions: controls + speed indicator 
-      // Keep inner controls in same order, just move X button to the front
-      
-      // First add the X button to the front
       const displayButton = buttons.find(btn => btn.action === 'display');
       if (displayButton) {
         const button = document.createElement('button');
@@ -196,7 +189,6 @@ class ShadowDOMManager {
         controls.appendChild(button);
       }
       
-      // Then add the inner controls in their original order
       const innerButtons = buttons.filter(btn => btn.action !== 'display');
       innerButtons.forEach((btnConfig) => {
         const button = document.createElement('button');
@@ -208,7 +200,6 @@ class ShadowDOMManager {
         controls.appendChild(button);
       });
       
-      // Add controls first, then speed indicator so speed shows on the right
       controller.appendChild(controls);
       controller.appendChild(draggable);
     }
@@ -273,10 +264,8 @@ class ShadowDOMManager {
    * @returns {Object} Position object with top and left properties
    */
   static calculatePosition(video, position = 'top-left') {
-    // For YouTube, try to use the player container instead of just the video element
     let targetElement = video;
     if (location.hostname === 'www.youtube.com') {
-      // Look for the YouTube player container that includes black bars
       const playerContainer = video.closest('.ytp-player-content.ytp-iv-player-content') || 
                              video.closest('.ytp-player-content') ||
                              video.closest('#movie_player') ||
@@ -288,9 +277,6 @@ class ShadowDOMManager {
 
     const rect = targetElement.getBoundingClientRect();
 
-    // getBoundingClientRect is relative to the viewport; style coordinates
-    // are relative to offsetParent, so we adjust for that here. offsetParent
-    // can be null if the video has `display: none` or is not yet in the DOM.
     const offsetRect = video.offsetParent?.getBoundingClientRect();
     
     const positionConfig = window.VSC.Constants.CONTROLLER_POSITIONS[position] || 
@@ -299,23 +285,17 @@ class ShadowDOMManager {
     let top, left;
     
     if (positionConfig.top) {
-      // Top positions
       top = `${Math.max(rect.top - (offsetRect?.top || 0), 0)}px`;
     } else {
-      // Bottom positions - need to account for controller height and video controls
-      let bottomOffset = 80; // Default offset
+      let bottomOffset = 80;
       
-      // YouTube-specific bottom positioning to avoid native controls
       if (location.hostname === 'www.youtube.com') {
-        // YouTube's control bar is typically around 40-50px, but we need extra space
-        // for our controller height (~30px) plus some margin
-        bottomOffset = 120; // Increased offset for YouTube
+        bottomOffset = 120;
         
-        // Try to detect if YouTube controls are visible and adjust accordingly
         const ytpControls = document.querySelector('.ytp-chrome-bottom');
         if (ytpControls) {
           const controlsHeight = ytpControls.offsetHeight || 40;
-          bottomOffset = Math.max(bottomOffset, controlsHeight + 50); // Controls height + controller + margin
+          bottomOffset = Math.max(bottomOffset, controlsHeight + 50);
         }
       }
       
@@ -324,12 +304,10 @@ class ShadowDOMManager {
     }
     
     if (positionConfig.left) {
-      // Left positions
       left = `${Math.max(rect.left - (offsetRect?.left || 0), 0)}px`;
     } else {
-      // Right positions - position with same padding as left (15px)
       const rightEdge = rect.right - (offsetRect?.left || 0);
-      left = `${Math.max(rightEdge - 15, 0)}px`; // Same 15px padding as left positions
+      left = `${Math.max(rightEdge - 15, 0)}px`;
     }
 
     return { top, left };

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -44,11 +44,13 @@ class ShadowDOMManager {
         color: white;
         border-radius: 6px;
         padding: 4px;
-        margin: 10px 10px 10px 15px;
         cursor: default;
         z-index: 9999999;
         white-space: nowrap;
-        ${positionConfig.left ? '' : 'display: flex; align-items: center; transform: translateX(-100%);'}
+        ${positionConfig.left 
+          ? 'margin: 10px 10px 10px 15px;' 
+          : 'transform: translateX(-100%); margin: 10px 15px 10px 10px;'
+        }
       }
       
       #controller:hover {
@@ -62,7 +64,6 @@ class ShadowDOMManager {
       #controls {
         display: none;
         white-space: nowrap;
-        ${positionConfig.left ? '' : 'order: -1;'}
       }
       
       #controller.dragging {
@@ -326,9 +327,9 @@ class ShadowDOMManager {
       // Left positions
       left = `${Math.max(rect.left - (offsetRect?.left || 0), 0)}px`;
     } else {
-      // Right positions - position at the right edge, transform will move it left
+      // Right positions - position with same padding as left (15px)
       const rightEdge = rect.right - (offsetRect?.left || 0);
-      left = `${Math.max(rightEdge, 0)}px`;
+      left = `${Math.max(rightEdge - 15, 0)}px`; // Same 15px padding as left positions
     }
 
     return { top, left };

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -234,7 +234,20 @@ class ShadowDOMManager {
    * @returns {Object} Position object with top and left properties
    */
   static calculatePosition(video, position = 'top-left') {
-    const rect = video.getBoundingClientRect();
+    // For YouTube, try to use the player container instead of just the video element
+    let targetElement = video;
+    if (location.hostname === 'www.youtube.com') {
+      // Look for the YouTube player container that includes black bars
+      const playerContainer = video.closest('.ytp-player-content.ytp-iv-player-content') || 
+                             video.closest('.ytp-player-content') ||
+                             video.closest('#movie_player') ||
+                             video.closest('.html5-video-player');
+      if (playerContainer) {
+        targetElement = playerContainer;
+      }
+    }
+
+    const rect = targetElement.getBoundingClientRect();
 
     // getBoundingClientRect is relative to the viewport; style coordinates
     // are relative to offsetParent, so we adjust for that here. offsetParent

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,6 +37,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,
+    controllerPosition: 'top-left', // default position
     keyBindings: [
       { action: 'slower', key: 83, value: 0.1, force: false, predefined: true }, // S
       { action: 'faster', key: 68, value: 0.1, force: false, predefined: true }, // D
@@ -106,12 +107,20 @@ meet.google.com`.replace(regStrip, ''),
 
   const CUSTOM_ACTIONS_NO_VALUES = ['pause', 'muted', 'mark', 'jump', 'display'];
 
+  const CONTROLLER_POSITIONS = {
+    'top-left': { top: true, left: true, label: 'Top Left' },
+    'top-right': { top: true, left: false, label: 'Top Right' },
+    'bottom-left': { top: false, left: true, label: 'Bottom Left' },
+    'bottom-right': { top: false, left: false, label: 'Bottom Right' }
+  };
+
   // Assign to global namespace
   window.VSC.Constants.LOG_LEVELS = LOG_LEVELS;
   window.VSC.Constants.MESSAGE_TYPES = MESSAGE_TYPES;
   window.VSC.Constants.SPEED_LIMITS = SPEED_LIMITS;
   window.VSC.Constants.CONTROLLER_SIZE_LIMITS = CONTROLLER_SIZE_LIMITS;
   window.VSC.Constants.CUSTOM_ACTIONS_NO_VALUES = CUSTOM_ACTIONS_NO_VALUES;
+  window.VSC.Constants.CONTROLLER_POSITIONS = CONTROLLER_POSITIONS;
 } // End conditional loading check
 
 // Global variables available for both browser and testing


### PR DESCRIPTION
Originally, the extension places the controls at the top left, but this PR introduces an option in settings to choose from top left, top right, bottom left and bottom right.
If placed on the right side, the controls are mirrored for proper alignment, meaning the controls will expand to the left (instead of the right) with mouse hover.
If placed at the bottom, they will adjust padding/offset to avoid overlaying with the original video controls.
IMPORTANT: I know very little of JS, so all edits were made by Copilot. I did extensive testing in a browser (as suggested in the guidelines) and believe all is fine, but a more detailed revision should be welcome.