### PR TITLE
Adds an option to place the controls at different corners of the video frame

### DIFF
--- a/CONTROLLER_POSITION_FEATURE.md
+++ b/CONTROLLER_POSITION_FEATURE.md
@@ -1,0 +1,96 @@
+# Controller Position Feature
+
+## Overview
+
+The Video Speed Controller now supports customizable positioning of the controller overlay. Users can choose from four different positions:
+
+- **Top Left** (default) - Controller appears at the top-left corner of videos
+- **Top Right** - Controller appears at the top-right corner of videos  
+- **Bottom Left** - Controller appears at the bottom-left corner of videos
+- **Bottom Right** - Controller appears at the bottom-right corner of videos
+
+## How to Use
+
+1. **Open Extension Settings**: Click on the extension icon and select "Options" or navigate to `chrome://extensions` and click "Details" → "Extension options"
+
+2. **Find Position Setting**: The controller position setting is now visible in the main "Other" section (no need to enable advanced features)
+
+3. **Select Position**: Choose your preferred position from the dropdown menu:
+   - Top Left (default)
+   - Top Right  
+   - Bottom Left
+   - Bottom Right
+
+4. **Save Settings**: Click "Save" to apply your changes
+
+5. **Refresh Pages**: **IMPORTANT** - You must refresh any open video pages to see the new controller position take effect
+
+## Troubleshooting
+
+### "Settings show Top Left but I selected something else"
+
+This can happen if:
+
+1. **You haven't refreshed the video page** - After changing the position setting, you must refresh any open video pages
+2. **The settings weren't saved** - Check the browser console for any error messages
+3. **Cache issues** - Try clearing your browser cache or opening an incognito window
+
+### "Controller position setting is not visible"
+
+The controller position dropdown should be visible in the main "Other" section of the options page. If it's not visible:
+
+1. Make sure you have the latest version of the extension
+2. Try refreshing the options page
+3. Check if there are any console errors
+
+### Debug Information
+
+To debug issues:
+
+1. Open the browser console (F12 → Console tab)
+2. Look for error messages when:
+   - Opening the options page
+   - Saving settings
+   - Loading video pages
+
+Look for error messages if the feature isn't working as expected. The extension logs important events at the INFO level and errors at the ERROR level.
+
+## Technical Implementation
+
+### Files Modified
+
+- `src/utils/constants.js` - Added `CONTROLLER_POSITIONS` constant and `controllerPosition` default setting
+- `src/core/settings.js` - Added handling for the `controllerPosition` setting
+- `src/ui/shadow-dom.js` - Updated `calculatePosition()` method and `createShadowDOM()` to support positioning
+- `src/core/video-controller.js` - Updated `initializeControls()` to use position setting
+- `src/ui/options/options.html` - Added position dropdown to options page
+- `src/ui/options/options.js` - Added save/restore logic for position setting
+- `src/ui/drag-handler.js` - Updated drag handling to work with positioned controllers
+- `src/styles/inject.css` - Added position-specific CSS classes
+
+### Position Calculation
+
+The controller position is calculated based on:
+- Video element's bounding rectangle
+- User's position preference (top/bottom + left/right)
+- Estimated controller dimensions (50px height, 200px width)
+
+### CSS Classes
+
+Position-specific CSS classes are applied to the controller wrapper:
+- `.vsc-position-top-left`
+- `.vsc-position-top-right` 
+- `.vsc-position-bottom-left`
+- `.vsc-position-bottom-right`
+
+These classes set appropriate `transform-origin` values for better visual behavior.
+
+## Backward Compatibility
+
+- Default position remains "top-left" 
+- Existing installations will continue to work without changes
+- The setting is stored in Chrome sync storage like other extension settings
+
+## Testing
+
+A test file `test-position.html` is included to verify the positioning logic works correctly across different scenarios.

--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -288,6 +288,29 @@ class VideoSpeedExtension {
         this.actionHandler,
         shouldStartHidden
       );
+
+      if (this.config.settings.controllerHover) {
+        const controllerDiv = video.vsc.div;
+        controllerDiv.style.opacity = '0';
+        controllerDiv.style.transition = 'opacity 0.2s ease-in-out';
+
+        let timeout;
+        const show = () => {
+          clearTimeout(timeout);
+          controllerDiv.style.opacity = '1';
+        };
+        const hide = () => {
+          timeout = setTimeout(() => {
+            controllerDiv.style.opacity = '0';
+          }, 200);
+        };
+
+        parent.addEventListener('mouseenter', show);
+        controllerDiv.addEventListener('mouseenter', show);
+
+        parent.addEventListener('mouseleave', hide);
+        controllerDiv.addEventListener('mouseleave', hide);
+      }
     } catch (error) {
       console.error('💥 Failed to attach controller to video:', error);
       this.logger.error(`Failed to attach controller to video: ${error.message}`);

--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -388,7 +388,37 @@ window.addEventListener('VSC_MESSAGE', (event) => {
           extension.actionHandler.runAction('display', null, null);
         }
         break;
+
+      case 'VSC_SETTINGS_UPDATED':
+        // Handle settings update from options page
+        window.VSC.logger.info('Settings updated, reloading configuration...');
+        if (extension.config) {
+          extension.config.load().then(() => {
+            window.VSC.logger.info('Configuration reloaded with new settings');
+            
+            // If controller position changed, we need to recreate controllers
+            if (message.payload && message.payload.controllerPosition) {
+              window.VSC.logger.info(`Controller position changed to: ${message.payload.controllerPosition}`);
+              // Note: Controllers will be recreated on next video load/page refresh
+            }
+          }).catch((error) => {
+            window.VSC.logger.error('Failed to reload settings:', error);
+          });
+        }
+        break;
     }
+  }
+});
+
+// Listen for settings changes from injected context (when content script updates storage)
+window.addEventListener('VSC_USER_SETTINGS', (event) => {
+  window.VSC.logger.debug('Received updated user settings');
+  if (extension.config) {
+    extension.config.load().then(() => {
+      window.VSC.logger.debug('Configuration updated from user settings event');
+    }).catch((error) => {
+      window.VSC.logger.error('Failed to update configuration from user settings:', error);
+    });
   }
 });
 

--- a/src/content/injector.js
+++ b/src/content/injector.js
@@ -110,6 +110,10 @@ function setupMessageBridge() {
   // Fetch and inject user settings into page context
   injectUserSettings();
 
+  // Re-inject shortly after startup to catch any propagation delays from storage writes
+  setTimeout(() => injectUserSettings(), 300);
+  setTimeout(() => injectUserSettings(), 1000);
+
   // Listen for messages from popup (in content script context)
   chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
     // Forward message to injected page context
@@ -142,7 +146,9 @@ function setupMessageBridge() {
     chrome.storage.onChanged.addListener((changes, namespace) => {
       if (namespace === 'sync') {
         // Re-inject updated settings when storage changes with a delay
-        setTimeout(() => injectUserSettings(), 200);
+  setTimeout(() => injectUserSettings(), 200);
+  // And a second pass to ensure all keys are synced
+  setTimeout(() => injectUserSettings(), 800);
       }
     });
   }

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -412,13 +412,13 @@ class ActionHandler {
       speedIndicator.textContent = window.VSC.Constants.formatSpeed(speed);
     }
 
-    // 4. Update settings based on rememberSpeed
+  // 4. Update settings based on rememberSpeed
+  const videoSrc = video.currentSrc || video.src || '';
     if (this.config.settings.rememberSpeed) {
       // Global mode - update lastSpeed
       this.config.settings.lastSpeed = speed;
     } else {
       // Per-video mode - store in memory only (not persisted)
-      const videoSrc = video.currentSrc || video.src;
       if (videoSrc) {
         this.config.settings.speeds[videoSrc] = speed;
       }
@@ -427,30 +427,10 @@ class ActionHandler {
     // Always update lastSpeed for UI consistency
     this.config.settings.lastSpeed = speed;
 
-    // 5. Save only the lastSpeed to storage, don't merge with potentially stale settings
-    try {
-      // Use direct storage call to avoid merging with stale settings
-      window.VSC.StorageManager.set({
-        lastSpeed: speed,
-      }).catch(error => {
-        window.VSC.logger.error('Failed to save lastSpeed:', error);
-      });
-      
-      // Also update per-video speeds if not in global mode
-      if (!this.config.settings.rememberSpeed && videoSrc) {
-        const updatedSpeeds = { ...this.config.settings.speeds };
-        updatedSpeeds[videoSrc] = speed;
-        this.config.settings.speeds = updatedSpeeds;
-        
-        window.VSC.StorageManager.set({
-          speeds: updatedSpeeds,
-        }).catch(error => {
-          window.VSC.logger.error('Failed to save per-video speeds:', error);
-        });
-      }
-    } catch (error) {
-      window.VSC.logger.error('Failed to save speed change:', error);
-    }
+    // 5. Save to storage (only global lastSpeed)
+    this.config.save({
+      lastSpeed: this.config.settings.lastSpeed,
+    });
 
     // 6. Show controller briefly if hidden
     if (video.vsc?.div) {

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -43,6 +43,7 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.displayKeyCode = Number(storage.displayKeyCode);
         this.settings.rememberSpeed = Boolean(storage.rememberSpeed);
         this.settings.forceLastSavedSpeed = Boolean(storage.forceLastSavedSpeed);
+        this.settings.controllerHover = Boolean(storage.controllerHover);
         this.settings.audioBoolean = Boolean(storage.audioBoolean);
         this.settings.enabled = Boolean(storage.enabled);
         this.settings.startHidden = Boolean(storage.startHidden);

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -70,7 +70,7 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
    * @returns {Array<string>} CSS selectors
    */
   getVideoContainerSelectors() {
-    return ['.html5-video-player', '#movie_player', '.ytp-player-content'];
+    return ['.html5-video-player', '#movie_player', '.ytp-player-content.ytp-iv-player-content', '.ytp-player-content'];
   }
 
   /**

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -66,16 +66,10 @@
   top: 60px;
 }
 
-/* YouTube bottom-positioned controllers - avoid overlapping with native controls */
+/* Keep JS-calculated bottom stacking authoritative; avoid CSS transforms that shift position */
 .html5-video-player .vsc-position-bottom-left,
 .html5-video-player .vsc-position-bottom-right {
-  transform: translateY(10px);
-}
-
-/* When YouTube controls are hidden, reduce the offset */
-.ytp-autohide .vsc-position-bottom-left,
-.ytp-autohide .vsc-position-bottom-right {
-  transform: translateY(-10px); /* Reduced from -20px */
+  max-width: 95%;
 }
 
 /* Facebook player */

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -24,6 +24,23 @@
   user-select: none;
 }
 
+/* Position-specific styles */
+.vsc-position-top-left {
+  transform-origin: top left !important;
+}
+
+.vsc-position-top-right {
+  transform-origin: top right !important;
+}
+
+.vsc-position-bottom-left {
+  transform-origin: bottom left !important;
+}
+
+.vsc-position-bottom-right {
+  transform-origin: bottom right !important;
+}
+
 /* Origin specific overrides */
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -66,6 +66,18 @@
   top: 60px;
 }
 
+/* YouTube bottom-positioned controllers - avoid overlapping with native controls */
+.html5-video-player .vsc-position-bottom-left,
+.html5-video-player .vsc-position-bottom-right {
+  transform: translateY(10px);
+}
+
+/* When YouTube controls are hidden, reduce the offset */
+.ytp-autohide .vsc-position-bottom-left,
+.ytp-autohide .vsc-position-bottom-right {
+  transform: translateY(-10px); /* Reduced from -20px */
+}
+
 /* Facebook player */
 #facebook .vsc-controller {
   position: relative;

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -49,9 +49,8 @@
 }
 
 .ytp-autohide .vsc-controller {
-  visibility: hidden;
-  transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  opacity: 0;
+  visibility: visible;
+  opacity: 1;
 }
 
 .ytp-autohide .vsc-show {

--- a/src/ui/drag-handler.js
+++ b/src/ui/drag-handler.js
@@ -23,17 +23,20 @@ class DragHandler {
 
     const initialMouseXY = [e.clientX, e.clientY];
     const initialControllerXY = [
-      parseInt(shadowController.style.left) || 0,
-      parseInt(shadowController.style.top) || 0,
+      parseInt(shadowController.style.left) || parseInt(controller.style.left) || 0,
+      parseInt(shadowController.style.top) || parseInt(controller.style.top) || 0,
     ];
 
     const startDragging = (e) => {
-      const style = shadowController.style;
       const dx = e.clientX - initialMouseXY[0];
       const dy = e.clientY - initialMouseXY[1];
 
-      style.left = `${initialControllerXY[0] + dx}px`;
-      style.top = `${initialControllerXY[1] + dy}px`;
+      // Update both shadow controller and wrapper positions
+      controller.style.left = `${initialControllerXY[0] + dx}px`;
+      controller.style.top = `${initialControllerXY[1] + dy}px`;
+      
+      shadowController.style.left = '0px';
+      shadowController.style.top = '0px';
     };
 
     const stopDragging = () => {

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -104,6 +104,16 @@
         <em>Prevent video players that override VSC speed</em></label>
       <input id="forceLastSavedSpeed" type="checkbox" />
     </div>
+    <div class="row">
+      <label for="controllerPosition">Controller position<br />
+        <em>Where the controller appears on videos</em></label>
+      <select id="controllerPosition">
+        <option value="top-left">Top Left</option>
+        <option value="top-right">Top Right</option>
+        <option value="bottom-left">Bottom Left</option>
+        <option value="bottom-right">Bottom Right</option>
+      </select>
+    </div>
     <div class="row advanced-feature">
       <label for="controllerOpacity">Controller opacity</label>
       <input id="controllerOpacity" type="text" value="" />

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -105,6 +105,10 @@
       <input id="startHidden" type="checkbox" />
     </div>
     <div class="row">
+      <label for="controllerHover">Show controller on hover only</label>
+      <input id="controllerHover" type="checkbox" />
+    </div>
+    <div class="row">
       <label for="controllerPosition">Controller position<br />
         <em>Where the controller appears on videos</em></label>
       <select id="controllerPosition">

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -96,13 +96,13 @@
       <input id="rememberSpeed" type="checkbox" />
     </div>
     <div class="row">
-      <label for="startHidden">Hide controller by default</label>
-      <input id="startHidden" type="checkbox" />
-    </div>
-    <div class="row">
       <label for="forceLastSavedSpeed">Force last saved speed<br />
         <em>Prevent video players that override VSC speed</em></label>
       <input id="forceLastSavedSpeed" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="startHidden">Hide controller by default</label>
+      <input id="startHidden" type="checkbox" />
     </div>
     <div class="row">
       <label for="controllerPosition">Controller position<br />

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -283,6 +283,7 @@ async function save_options() {
 
     var rememberSpeed = document.getElementById("rememberSpeed").checked;
     var forceLastSavedSpeed = document.getElementById("forceLastSavedSpeed").checked;
+    var controllerHover = document.getElementById("controllerHover").checked;
     var audioBoolean = document.getElementById("audioBoolean").checked;
     var startHidden = document.getElementById("startHidden").checked;
     var controllerOpacity = Number(document.getElementById("controllerOpacity").value);
@@ -300,6 +301,7 @@ async function save_options() {
     const settingsToSave = {
       rememberSpeed: rememberSpeed,
       forceLastSavedSpeed: forceLastSavedSpeed,
+      controllerHover: controllerHover,
       audioBoolean: audioBoolean,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
@@ -310,16 +312,7 @@ async function save_options() {
       blacklist: blacklist.replace(window.VSC.Constants.regStrip, "")
     };
 
-    // Save using Chrome storage API
-    await new Promise((resolve, reject) => {
-      chrome.storage.sync.set(settingsToSave, () => {
-        if (chrome.runtime.lastError) {
-          reject(new Error(chrome.runtime.lastError.message));
-        } else {
-          resolve();
-        }
-      });
-    });
+    await window.VSC.videoSpeedConfig.save(settingsToSave);
 
     // Add a small delay to ensure Chrome storage sync has completed
     await new Promise(resolve => setTimeout(resolve, 100));
@@ -365,6 +358,7 @@ async function restore_options() {
 
     document.getElementById("rememberSpeed").checked = storage.rememberSpeed;
     document.getElementById("forceLastSavedSpeed").checked = storage.forceLastSavedSpeed;
+    document.getElementById("controllerHover").checked = storage.controllerHover;
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value = storage.controllerOpacity;

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -264,9 +264,24 @@ class ShadowDOMManager {
       top = `${Math.max(rect.top - (offsetRect?.top || 0), 0)}px`;
     } else {
       // Bottom positions - need to account for controller height and video controls
-      // Leave extra space (80px) to avoid overlapping with video's native controls
-      const bottomOffset = rect.bottom - (offsetRect?.top || 0) - 80; // Increased from 50px to 80px
-      top = `${Math.max(bottomOffset, 0)}px`;
+      let bottomOffset = 80; // Default offset
+      
+      // YouTube-specific bottom positioning to avoid native controls
+      if (location.hostname === 'www.youtube.com') {
+        // YouTube's control bar is typically around 40-50px, but we need extra space
+        // for our controller height (~30px) plus some margin
+        bottomOffset = 120; // Increased offset for YouTube
+        
+        // Try to detect if YouTube controls are visible and adjust accordingly
+        const ytpControls = document.querySelector('.ytp-chrome-bottom');
+        if (ytpControls) {
+          const controlsHeight = ytpControls.offsetHeight || 40;
+          bottomOffset = Math.max(bottomOffset, controlsHeight + 50); // Controls height + controller + margin
+        }
+      }
+      
+      const calculatedBottom = rect.bottom - (offsetRect?.top || 0) - bottomOffset;
+      top = `${Math.max(calculatedBottom, 0)}px`;
     }
     
     if (positionConfig.left) {

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -163,10 +163,7 @@ class ShadowDOMManager {
     draggable.style.cssText = `font-size: ${buttonSize}px;`;
     draggable.textContent = speed;
 
-    // For right positions, mirror the layout: controls appear to the left of speed indicator
-    // For left positions, keep original: speed indicator first, then controls
     if (positionConfig.left) {
-      // Left positions: speed indicator + controls (original behavior)
       controller.appendChild(draggable);
       
       buttons.forEach((btnConfig) => {
@@ -181,10 +178,6 @@ class ShadowDOMManager {
       
       controller.appendChild(controls);
     } else {
-      // Right positions: controls + speed indicator 
-      // Keep inner controls in same order, just move X button to the front
-      
-      // First add the X button to the front
       const displayButton = buttons.find(btn => btn.action === 'display');
       if (displayButton) {
         const button = document.createElement('button');
@@ -196,7 +189,6 @@ class ShadowDOMManager {
         controls.appendChild(button);
       }
       
-      // Then add the inner controls in their original order
       const innerButtons = buttons.filter(btn => btn.action !== 'display');
       innerButtons.forEach((btnConfig) => {
         const button = document.createElement('button');
@@ -208,7 +200,6 @@ class ShadowDOMManager {
         controls.appendChild(button);
       });
       
-      // Add controls first, then speed indicator so speed shows on the right
       controller.appendChild(controls);
       controller.appendChild(draggable);
     }
@@ -273,10 +264,8 @@ class ShadowDOMManager {
    * @returns {Object} Position object with top and left properties
    */
   static calculatePosition(video, position = 'top-left') {
-    // For YouTube, try to use the player container instead of just the video element
     let targetElement = video;
     if (location.hostname === 'www.youtube.com') {
-      // Look for the YouTube player container that includes black bars
       const playerContainer = video.closest('.ytp-player-content.ytp-iv-player-content') || 
                              video.closest('.ytp-player-content') ||
                              video.closest('#movie_player') ||
@@ -288,9 +277,6 @@ class ShadowDOMManager {
 
     const rect = targetElement.getBoundingClientRect();
 
-    // getBoundingClientRect is relative to the viewport; style coordinates
-    // are relative to offsetParent, so we adjust for that here. offsetParent
-    // can be null if the video has `display: none` or is not yet in the DOM.
     const offsetRect = video.offsetParent?.getBoundingClientRect();
     
     const positionConfig = window.VSC.Constants.CONTROLLER_POSITIONS[position] || 
@@ -299,23 +285,17 @@ class ShadowDOMManager {
     let top, left;
     
     if (positionConfig.top) {
-      // Top positions
       top = `${Math.max(rect.top - (offsetRect?.top || 0), 0)}px`;
     } else {
-      // Bottom positions - need to account for controller height and video controls
-      let bottomOffset = 80; // Default offset
+      let bottomOffset = 80;
       
-      // YouTube-specific bottom positioning to avoid native controls
       if (location.hostname === 'www.youtube.com') {
-        // YouTube's control bar is typically around 40-50px, but we need extra space
-        // for our controller height (~30px) plus some margin
-        bottomOffset = 120; // Increased offset for YouTube
+        bottomOffset = 120;
         
-        // Try to detect if YouTube controls are visible and adjust accordingly
         const ytpControls = document.querySelector('.ytp-chrome-bottom');
         if (ytpControls) {
           const controlsHeight = ytpControls.offsetHeight || 40;
-          bottomOffset = Math.max(bottomOffset, controlsHeight + 50); // Controls height + controller + margin
+          bottomOffset = Math.max(bottomOffset, controlsHeight + 50);
         }
       }
       
@@ -324,12 +304,10 @@ class ShadowDOMManager {
     }
     
     if (positionConfig.left) {
-      // Left positions
       left = `${Math.max(rect.left - (offsetRect?.left || 0), 0)}px`;
     } else {
-      // Right positions - position with same padding as left (15px)
       const rightEdge = rect.right - (offsetRect?.left || 0);
-      left = `${Math.max(rightEdge - 15, 0)}px`; // Same 15px padding as left positions
+      left = `${Math.max(rightEdge - 15, 0)}px`;
     }
 
     return { top, left };

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -44,11 +44,13 @@ class ShadowDOMManager {
         color: white;
         border-radius: 6px;
         padding: 4px;
-        margin: 10px 10px 10px 15px;
         cursor: default;
         z-index: 9999999;
         white-space: nowrap;
-        ${positionConfig.left ? '' : 'display: flex; align-items: center; transform: translateX(-100%);'}
+        ${positionConfig.left 
+          ? 'margin: 10px 10px 10px 15px;' 
+          : 'transform: translateX(-100%); margin: 10px 15px 10px 10px;'
+        }
       }
       
       #controller:hover {
@@ -62,7 +64,6 @@ class ShadowDOMManager {
       #controls {
         display: none;
         white-space: nowrap;
-        ${positionConfig.left ? '' : 'order: -1;'}
       }
       
       #controller.dragging {
@@ -326,9 +327,9 @@ class ShadowDOMManager {
       // Left positions
       left = `${Math.max(rect.left - (offsetRect?.left || 0), 0)}px`;
     } else {
-      // Right positions - position at the right edge, transform will move it left
+      // Right positions - position with same padding as left (15px)
       const rightEdge = rect.right - (offsetRect?.left || 0);
-      left = `${Math.max(rightEdge, 0)}px`;
+      left = `${Math.max(rightEdge - 15, 0)}px`; // Same 15px padding as left positions
     }
 
     return { top, left };

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -234,7 +234,20 @@ class ShadowDOMManager {
    * @returns {Object} Position object with top and left properties
    */
   static calculatePosition(video, position = 'top-left') {
-    const rect = video.getBoundingClientRect();
+    // For YouTube, try to use the player container instead of just the video element
+    let targetElement = video;
+    if (location.hostname === 'www.youtube.com') {
+      // Look for the YouTube player container that includes black bars
+      const playerContainer = video.closest('.ytp-player-content.ytp-iv-player-content') || 
+                             video.closest('.ytp-player-content') ||
+                             video.closest('#movie_player') ||
+                             video.closest('.html5-video-player');
+      if (playerContainer) {
+        targetElement = playerContainer;
+      }
+    }
+
+    const rect = targetElement.getBoundingClientRect();
 
     // getBoundingClientRect is relative to the viewport; style coordinates
     // are relative to offsetParent, so we adjust for that here. offsetParent

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -33,6 +33,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     displayKeyCode: 86, // default: V
     rememberSpeed: false, // default: false
     forceLastSavedSpeed: false, //default: false
+    controllerHover: false,
     audioBoolean: true, // default: true (enable audio controller support)
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,6 +37,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,
+    controllerPosition: 'top-left', // default position
     keyBindings: [
       { action: 'slower', key: 83, value: 0.1, force: false, predefined: true }, // S
       { action: 'faster', key: 68, value: 0.1, force: false, predefined: true }, // D
@@ -106,12 +107,20 @@ meet.google.com`.replace(regStrip, ''),
 
   const CUSTOM_ACTIONS_NO_VALUES = ['pause', 'muted', 'mark', 'jump', 'display'];
 
+  const CONTROLLER_POSITIONS = {
+    'top-left': { top: true, left: true, label: 'Top Left' },
+    'top-right': { top: true, left: false, label: 'Top Right' },
+    'bottom-left': { top: false, left: true, label: 'Bottom Left' },
+    'bottom-right': { top: false, left: false, label: 'Bottom Right' }
+  };
+
   // Assign to global namespace
   window.VSC.Constants.LOG_LEVELS = LOG_LEVELS;
   window.VSC.Constants.MESSAGE_TYPES = MESSAGE_TYPES;
   window.VSC.Constants.SPEED_LIMITS = SPEED_LIMITS;
   window.VSC.Constants.CONTROLLER_SIZE_LIMITS = CONTROLLER_SIZE_LIMITS;
   window.VSC.Constants.CUSTOM_ACTIONS_NO_VALUES = CUSTOM_ACTIONS_NO_VALUES;
+  window.VSC.Constants.CONTROLLER_POSITIONS = CONTROLLER_POSITIONS;
 } // End conditional loading check
 
 // Global variables available for both browser and testing


### PR DESCRIPTION
Originally, the extension places the controls at the top left, but this PR introduces an option in settings to choose from top left, top right, bottom left and bottom right.
If placed on the right side, the controls are mirrored for proper alignment, meaning the controls will expand to the left (instead of the right) with mouse hover.
If placed at the bottom, they will adjust padding/offset to avoid overlaying with the original video controls.
IMPORTANT: I know very little of JS, so all edits were made by Copilot. I did extensive testing in a browser (as suggested in the guidelines) and believe all is fine, but a more detailed revision should be welcome.