### PR TITLE
Adds an option to place the controls at different corners of the video frame

### DIFF
--- a/CONTROLLER_POSITION_IMPLEMENTATION.md
+++ b/CONTROLLER_POSITION_IMPLEMENTATION.md
@@ -1,0 +1,53 @@
+# Controller Position Implementation Summary
+
+This implementation adds essential controller position functionality to the `control-pos` branch, copying only the necessary code from the `control-position` branch.
+
+## Features Added:
+
+### 1. Controller Position Settings
+- **controllerPosition**: String setting with options: 'top-left', 'top-right', 'bottom-left', 'bottom-right'
+- **controllerHover**: Boolean setting for hover-only display (secondary trait)
+
+### 2. Position Configuration System
+- `CONTROLLER_POSITIONS` constant defining position configurations
+- Each position has `top`, `left` boolean properties for layout logic
+
+### 3. Enhanced Shadow DOM Creation
+- Position-aware CSS generation with different layouts for left vs right positioning
+- Button reordering for right-aligned positions (display button moves to left)
+- Position-specific margin and transform styles
+
+### 4. Position Calculation
+- Enhanced `calculatePosition()` method supporting user position preference
+- Basic offset calculation for bottom positioning (simplified version)
+- Site-specific container detection (especially for YouTube)
+
+### 5. CSS Position Classes
+- `.vsc-position-top-left`, `.vsc-position-top-right`, etc.
+- Transform-origin styles for proper scaling from corners
+
+### 6. Options UI
+- Controller position dropdown in options page
+- Controller hover checkbox
+- Proper save/restore functionality
+
+### 7. Updated Components
+- **video-controller.js**: Passes position to shadow DOM, adds position classes
+- **drag-handler.js**: Updated to work with new positioning system
+- **settings.js**: Loads and saves new settings
+- **options.js**: Handles new UI controls
+
+## What Was NOT Included:
+- Complex bottom overlay detection logic
+- Detailed native controls height detection 
+- Site-specific control height calculations
+- Advanced bottom stacking algorithms
+- Enforcement timers and speed persistence logic
+- Resize handlers and dynamic position updates
+
+## Key Simplifications:
+- Basic bottom positioning with fixed 60px offset instead of dynamic detection
+- Simplified position calculation without complex overlay detection
+- Essential CSS classes only, no advanced transform logic
+
+This provides the core controller positioning functionality while keeping the implementation minimal and focused on the essential features requested.

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -42,11 +42,15 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.displayKeyCode = Number(storage.displayKeyCode);
         this.settings.rememberSpeed = Boolean(storage.rememberSpeed);
         this.settings.forceLastSavedSpeed = Boolean(storage.forceLastSavedSpeed);
+        this.settings.controllerHover = Boolean(storage.controllerHover);
         this.settings.audioBoolean = Boolean(storage.audioBoolean);
         this.settings.enabled = Boolean(storage.enabled);
         this.settings.startHidden = Boolean(storage.startHidden);
         this.settings.controllerOpacity = Number(storage.controllerOpacity);
         this.settings.controllerButtonSize = Number(storage.controllerButtonSize);
+        this.settings.controllerPosition = String(
+          storage.controllerPosition || window.VSC.Constants.DEFAULT_SETTINGS.controllerPosition
+        );
         this.settings.blacklist = String(storage.blacklist);
         this.settings.logLevel = Number(
           storage.logLevel || window.VSC.Constants.DEFAULT_SETTINGS.logLevel

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -99,8 +99,12 @@ class VideoController {
     window.VSC.logger.debug('initializeControls Begin');
 
     const document = this.video.ownerDocument;
+    // For the UI indicator, reflect the actual current playback rate
     const speed = window.VSC.Constants.formatSpeed(this.video.playbackRate);
-    const position = window.VSC.ShadowDOMManager.calculatePosition(this.video);
+    
+    // Get position based on user preference
+    const userPosition = this.config.settings.controllerPosition || 'top-left';
+    const position = window.VSC.ShadowDOMManager.calculatePosition(this.video, userPosition);
 
     window.VSC.logger.debug(`Speed variable set to: ${speed}`);
 
@@ -108,7 +112,7 @@ class VideoController {
     const wrapper = document.createElement('div');
 
     // Apply all CSS classes at once to prevent race condition flash
-    const cssClasses = ['vsc-controller'];
+    const cssClasses = ['vsc-controller', `vsc-position-${userPosition}`];
 
     // Only hide controller if video has no source AND is not ready/functional
     // This prevents hiding controllers for live streams or dynamically loaded videos
@@ -160,6 +164,7 @@ class VideoController {
       speed: speed,
       opacity: this.config.settings.controllerOpacity,
       buttonSize: this.config.settings.controllerButtonSize,
+      position: userPosition, // Pass position to shadow DOM
     });
 
     // Set up control events

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -24,6 +24,23 @@
   user-select: none;
 }
 
+/* Position-specific styles */
+.vsc-position-top-left {
+  transform-origin: top left !important;
+}
+
+.vsc-position-top-right {
+  transform-origin: top right !important;
+}
+
+.vsc-position-bottom-left {
+  transform-origin: bottom left !important;
+}
+
+.vsc-position-bottom-right {
+  transform-origin: bottom right !important;
+}
+
 /* Origin specific overrides */
 /* YouTube player */
 .ytp-hide-info-bar .vsc-controller {

--- a/src/ui/drag-handler.js
+++ b/src/ui/drag-handler.js
@@ -23,17 +23,20 @@ class DragHandler {
 
     const initialMouseXY = [e.clientX, e.clientY];
     const initialControllerXY = [
-      parseInt(shadowController.style.left) || 0,
-      parseInt(shadowController.style.top) || 0,
+      parseInt(shadowController.style.left) || parseInt(controller.style.left) || 0,
+      parseInt(shadowController.style.top) || parseInt(controller.style.top) || 0,
     ];
 
     const startDragging = (e) => {
-      const style = shadowController.style;
       const dx = e.clientX - initialMouseXY[0];
       const dy = e.clientY - initialMouseXY[1];
 
-      style.left = `${initialControllerXY[0] + dx}px`;
-      style.top = `${initialControllerXY[1] + dy}px`;
+      // Update both shadow controller and wrapper positions
+      controller.style.left = `${initialControllerXY[0] + dx}px`;
+      controller.style.top = `${initialControllerXY[1] + dy}px`;
+      
+      shadowController.style.left = '0px';
+      shadowController.style.top = '0px';
     };
 
     const stopDragging = () => {

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -100,6 +100,20 @@
       <input id="startHidden" type="checkbox" />
     </div>
     <div class="row">
+      <label for="controllerHover">Show controller on hover only</label>
+      <input id="controllerHover" type="checkbox" />
+    </div>
+    <div class="row">
+      <label for="controllerPosition">Controller position<br />
+        <em>Where the controller appears on videos</em></label>
+      <select id="controllerPosition">
+        <option value="top-left">Top Left</option>
+        <option value="top-right">Top Right</option>
+        <option value="bottom-left">Bottom Left</option>
+        <option value="bottom-right">Bottom Right</option>
+      </select>
+    </div>
+    <div class="row">
       <label for="forceLastSavedSpeed">Force last saved speed<br />
         <em>Prevent video players that override VSC speed</em></label>
       <input id="forceLastSavedSpeed" type="checkbox" />

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -283,10 +283,12 @@ async function save_options() {
 
     var rememberSpeed = document.getElementById("rememberSpeed").checked;
     var forceLastSavedSpeed = document.getElementById("forceLastSavedSpeed").checked;
+    var controllerHover = document.getElementById("controllerHover").checked;
     var audioBoolean = document.getElementById("audioBoolean").checked;
     var startHidden = document.getElementById("startHidden").checked;
     var controllerOpacity = Number(document.getElementById("controllerOpacity").value);
     var controllerButtonSize = Number(document.getElementById("controllerButtonSize").value);
+    var controllerPosition = document.getElementById("controllerPosition").value;
     var logLevel = parseInt(document.getElementById("logLevel").value);
     var blacklist = document.getElementById("blacklist").value;
 
@@ -299,10 +301,12 @@ async function save_options() {
     const settingsToSave = {
       rememberSpeed: rememberSpeed,
       forceLastSavedSpeed: forceLastSavedSpeed,
+      controllerHover: controllerHover,
       audioBoolean: audioBoolean,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       controllerButtonSize: controllerButtonSize,
+      controllerPosition: controllerPosition,
       logLevel: logLevel,
       keyBindings: keyBindings,
       blacklist: blacklist.replace(window.VSC.Constants.regStrip, "")
@@ -351,10 +355,12 @@ async function restore_options() {
 
     document.getElementById("rememberSpeed").checked = storage.rememberSpeed;
     document.getElementById("forceLastSavedSpeed").checked = storage.forceLastSavedSpeed;
+    document.getElementById("controllerHover").checked = storage.controllerHover;
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value = storage.controllerOpacity;
     document.getElementById("controllerButtonSize").value = storage.controllerButtonSize;
+    document.getElementById("controllerPosition").value = storage.controllerPosition || 'top-left';
     document.getElementById("logLevel").value = storage.logLevel;
     document.getElementById("blacklist").value = storage.blacklist;
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -33,10 +33,12 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     displayKeyCode: 86, // default: V
     rememberSpeed: false, // default: false
     forceLastSavedSpeed: false, //default: false
+    controllerHover: false,
     audioBoolean: true, // default: true (enable audio controller support)
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,
+    controllerPosition: 'top-left', // default position
     keyBindings: [
       { action: 'slower', key: 83, value: 0.1, force: false, predefined: true }, // S
       { action: 'faster', key: 68, value: 0.1, force: false, predefined: true }, // D
@@ -106,12 +108,20 @@ meet.google.com`.replace(regStrip, ''),
 
   const CUSTOM_ACTIONS_NO_VALUES = ['pause', 'muted', 'mark', 'jump', 'display'];
 
+  const CONTROLLER_POSITIONS = {
+    'top-left': { top: true, left: true, label: 'Top Left' },
+    'top-right': { top: true, left: false, label: 'Top Right' },
+    'bottom-left': { top: false, left: true, label: 'Bottom Left' },
+    'bottom-right': { top: false, left: false, label: 'Bottom Right' }
+  };
+
   // Assign to global namespace
   window.VSC.Constants.LOG_LEVELS = LOG_LEVELS;
   window.VSC.Constants.MESSAGE_TYPES = MESSAGE_TYPES;
   window.VSC.Constants.SPEED_LIMITS = SPEED_LIMITS;
   window.VSC.Constants.CONTROLLER_SIZE_LIMITS = CONTROLLER_SIZE_LIMITS;
   window.VSC.Constants.CUSTOM_ACTIONS_NO_VALUES = CUSTOM_ACTIONS_NO_VALUES;
+  window.VSC.Constants.CONTROLLER_POSITIONS = CONTROLLER_POSITIONS;
 } // End conditional loading check
 
 // Global variables available for both browser and testing


### PR DESCRIPTION
*** I am creating a new PR because I pruned the edits from the previous PR, to add as minimum edits as possible. ***
Originally, the extension places the controls at the top left, but this PR introduces an option in settings to choose from top left, top right, bottom left and bottom right.
If placed on the right side, the controls are mirrored for proper alignment, meaning the controls will expand to the left (instead of the right) with mouse hover.
If placed at the bottom, they will adjust padding/offset to avoid overlaying with the original video controls.
Another feature is to show the controls only on mouse hover, this can be enabled in settings.
I added a video showing how the new features work. (The first time using bottom-right, I was too quick to reload the page, then it didn't work at first.)
IMPORTANT: I know very little of JS, so all edits were made by Copilot. I did extensive testing in a browser (as suggested in the guidelines) and believe all is fine, but a more detailed revision should be welcome.

https://github.com/user-attachments/assets/f099b9c7-17e4-48ef-b00f-5dab8f1075e2

