### PR TITLE
[fix/issue-1291-default-to-x0.07] fix speed defaulting to 0.07

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -383,7 +383,7 @@ class ActionHandler {
 
     // Clamp to valid range
     targetSpeed = Math.min(
-      Math.max(targetSpeed, window.VSC.Constants.SPEED_LIMITS.MIN),
+      Math.max(targetSpeed || 1, window.VSC.Constants.SPEED_LIMITS.MIN),
       window.VSC.Constants.SPEED_LIMITS.MAX
     );
 


### PR DESCRIPTION
This PR fixes issues #1291 and #1293 where those platforms by default set the video playback rate to 0, resulting in using the `window.VSC.Constants.SPEED_LIMITS.MIN` 
Instead this checks if the `playbackrate = 0` it uses 1 instead 