### PR TITLE
Add controller positioning options

### DIFF
--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -42,6 +42,7 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.startHidden = Boolean(storage.startHidden);
         this.settings.controllerOpacity = Number(storage.controllerOpacity);
         this.settings.controllerButtonSize = Number(storage.controllerButtonSize);
+        this.settings.controllerPosition = String(storage.controllerPosition || 'top-left');
         this.settings.blacklist = String(storage.blacklist);
         this.settings.logLevel = Number(
           storage.logLevel || window.VSC.Constants.DEFAULT_SETTINGS.logLevel

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -100,7 +100,7 @@ class VideoController {
 
     const document = this.video.ownerDocument;
     const speed = window.VSC.Constants.formatSpeed(this.video.playbackRate);
-    const position = window.VSC.ShadowDOMManager.calculatePosition(this.video);
+    const position = window.VSC.ShadowDOMManager.calculatePosition(this.video, this.config.settings.controllerPosition);
 
     window.VSC.logger.debug(`Speed variable set to: ${speed}`);
 

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -109,6 +109,17 @@
       <input id="controllerButtonSize" type="text" value="" />
     </div>
     <div class="row advanced-feature">
+      <label for="controllerPosition">Controller Position</label>
+      <select id="controllerPosition">
+        <option value="top-left">Top Left</option>
+        <option value="top-center">Top Center</option>
+        <option value="top-right">Top Right</option>
+        <option value="bottom-left">Bottom Left</option>
+        <option value="bottom-center">Bottom Center</option>
+        <option value="bottom-right">Bottom Right</option>
+      </select>
+    </div>
+    <div class="row advanced-feature">
       <label for="logLevel">Console Log Level<br />
         <em>Set verbosity in the browser console</em></label>
       <select id="logLevel">

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -300,6 +300,7 @@ async function save_options() {
     var startHidden = document.getElementById("startHidden").checked;
     var controllerOpacity = Number(document.getElementById("controllerOpacity").value);
     var controllerButtonSize = Number(document.getElementById("controllerButtonSize").value);
+    var controllerPosition = document.getElementById("controllerPosition").value;
     var logLevel = parseInt(document.getElementById("logLevel").value);
     var blacklist = document.getElementById("blacklist").value;
 
@@ -316,6 +317,7 @@ async function save_options() {
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
       controllerButtonSize: controllerButtonSize,
+      controllerPosition: controllerPosition,
       logLevel: logLevel,
       keyBindings: keyBindings,
       blacklist: blacklist.replace(window.VSC.Constants.regStrip, "")
@@ -361,6 +363,7 @@ async function restore_options() {
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value = storage.controllerOpacity;
     document.getElementById("controllerButtonSize").value = storage.controllerButtonSize;
+    document.getElementById("controllerPosition").value = storage.controllerPosition || 'top-left';
     document.getElementById("logLevel").value = storage.logLevel;
     document.getElementById("blacklist").value = storage.blacklist;
 

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -218,21 +218,65 @@ class ShadowDOMManager {
   }
 
   /**
-   * Calculate position for controller based on video element
+   * Calculate position for controller based on video element and position preference
    * @param {HTMLVideoElement} video - Video element
+   * @param {string} position - Position preference (top-left, top-center, top-right, bottom-left, bottom-center, bottom-right)
    * @returns {Object} Position object with top and left properties
    */
-  static calculatePosition(video) {
+  static calculatePosition(video, position = 'top-left') {
     const rect = video.getBoundingClientRect();
 
     // getBoundingClientRect is relative to the viewport; style coordinates
     // are relative to offsetParent, so we adjust for that here. offsetParent
     // can be null if the video has `display: none` or is not yet in the DOM.
     const offsetRect = video.offsetParent?.getBoundingClientRect();
-    const top = `${Math.max(rect.top - (offsetRect?.top || 0), 0)}px`;
-    const left = `${Math.max(rect.left - (offsetRect?.left || 0), 0)}px`;
+    
+    const baseTop = rect.top - (offsetRect?.top || 0);
+    const baseLeft = rect.left - (offsetRect?.left || 0);
+    
+    let top, left;
+    
+    switch (position) {
+      case 'top-left':
+        top = Math.max(baseTop, 0);
+        left = Math.max(baseLeft, 0);
+        break;
+        
+      case 'top-center':
+        top = Math.max(baseTop, 0);
+        left = Math.max(baseLeft + (rect.width / 2) - 50, 0); // Approximate controller width offset
+        break;
+        
+      case 'top-right':
+        top = Math.max(baseTop, 0);
+        left = Math.max(baseLeft + rect.width - 100, 0); // Approximate controller width
+        break;
+        
+      case 'bottom-left':
+        top = Math.max(baseTop + rect.height - 30, 0); // Approximate controller height
+        left = Math.max(baseLeft, 0);
+        break;
+        
+      case 'bottom-center':
+        top = Math.max(baseTop + rect.height - 30, 0); // Approximate controller height
+        left = Math.max(baseLeft + (rect.width / 2) - 50, 0); // Approximate controller width offset
+        break;
+        
+      case 'bottom-right':
+        top = Math.max(baseTop + rect.height - 30, 0); // Approximate controller height
+        left = Math.max(baseLeft + rect.width - 100, 0); // Approximate controller width
+        break;
+        
+      default:
+        // Default to top-left
+        top = Math.max(baseTop, 0);
+        left = Math.max(baseLeft, 0);
+    }
 
-    return { top, left };
+    return { 
+      top: `${top}px`, 
+      left: `${left}px` 
+    };
   }
 }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -27,6 +27,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,
+    controllerPosition: 'top-left', // default: top-left
     keyBindings: [
       { action: 'slower', key: 83, value: 0.1, force: false, predefined: true }, // S
       { action: 'faster', key: 68, value: 0.1, force: false, predefined: true }, // D


### PR DESCRIPTION
## Description
Adds controller positioning options to allow users to choose where the speed controller appears on videos.

## Changes
- Added `controllerPosition` setting with 6 options: top-left, top-center, top-right, bottom-left, bottom-center, bottom-right  
- Updated options UI with dropdown in advanced settings
- Modified positioning logic to calculate correct positions for all options
- All existing tests pass

## Fixes
Resolves the issue where the controller overlaps with video player controls (like Plex minimize button) by allowing users to position it elsewhere.

## Testing
- Tested all 6 positioning options on multiple video sites
- Verified settings persist across browser sessions
- All existing tests continue to pass