### PR TITLE
lastSpeed setting only used when rememberSpeed is enabled

### DIFF
--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -33,7 +33,6 @@ if (!window.VSC.VideoSpeedConfig) {
         }
 
         // Apply loaded settings
-        this.settings.lastSpeed = Number(storage.lastSpeed);
         this.settings.displayKeyCode = Number(storage.displayKeyCode);
         this.settings.rememberSpeed = Boolean(storage.rememberSpeed);
         this.settings.forceLastSavedSpeed = Boolean(storage.forceLastSavedSpeed);
@@ -46,6 +45,7 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.logLevel = Number(
           storage.logLevel || window.VSC.Constants.DEFAULT_SETTINGS.logLevel
         );
+        this.settings.lastSpeed = this.settings.rememberSpeed ? Number(storage.lastSpeed) : 1.0;
 
         // Ensure display binding exists (for upgrades)
         this.ensureDisplayBinding(storage);


### PR DESCRIPTION
when loading settings, lastSpeed will be set to 1 if rememberSpeed is not set, regardless of what is stored. This should fix issues where people not using 'remember speed' have their videos always starting at whatever is saved to lastSpeed, but lastSpeed never updates. See https://github.com/igrigorik/videospeed/issues/1341, https://github.com/igrigorik/videospeed/issues/1328, https://github.com/igrigorik/videospeed/issues/1324, https://github.com/igrigorik/videospeed/issues/1327/

Note: I was not able to build the project to test it, I was having trouble getting it working on Windows. If someone can build it to confirm it works  that would be great, or give me pointers on building it - I don't have a huge amount of experience with node. Below is the issue it's throwing:
```
PS C:\Users\westn\Documents\code\videospeed> npm run build

> video-speed-controller@0.8.0 prebuild
> rm -rf dist

'rm' is not recognized as an internal or external command,
operable program or batch file.
```
I'm on windows 11 - like I said I'll keep looking into it to see if I can get a build working. Also tried WSL, that had different issues.