### PR TITLE
Fix: Lower VSC controller on YouTube fullscreen to prevent overlap

### DIFF
--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -78,6 +78,12 @@ a[aria-label^="Video"] vsc-controller {
   top: 100px !important;
 }
 
+/* Move VSC controller down in YouTube fullscreen to avoid title overlap */
+.ytp-fullscreen vsc-controller {
+  position: relative;
+  top: 40px !important;
+}
+
 /* disable Vimeo video overlay */
 div.video-wrapper+div.target {
   height: 0;


### PR DESCRIPTION
**Problem:**
When viewing a YouTube video in full screen, the video title at the top overlaps and hides the Video Speed Controller.

**Solution:**
This PR adds a specific CSS rule to move the controller down by 40px when YouTube is in full screen mode (`.ytp-fullscreen`), preventing the overlap.