### PR TITLE
Add optional snap-to-1.0x feature

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -393,6 +393,14 @@ class ActionHandler {
       // For relative changes, add to current speed
       const currentSpeed = video.playbackRate < 0.1 ? 0.0 : video.playbackRate;
       targetSpeed = currentSpeed + value;
+
+      // Snap to 1.0x when crossing the 1.0 boundary (unless disabled)
+      if (!this.config.settings.disableSnapToOne &&
+          ((currentSpeed > 1.0 && targetSpeed < 1.0) || (currentSpeed < 1.0 && targetSpeed > 1.0))) {
+        targetSpeed = 1.0;
+        window.VSC.logger.debug(`Snapping to 1.0x (was crossing boundary from ${currentSpeed})`);
+      }
+
       window.VSC.logger.debug(`Relative speed calculation: currentSpeed=${currentSpeed} + ${value} = ${targetSpeed}`);
     } else {
       // For absolute changes, use value directly

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -37,6 +37,7 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.displayKeyCode = Number(storage.displayKeyCode);
         this.settings.rememberSpeed = Boolean(storage.rememberSpeed);
         this.settings.forceLastSavedSpeed = Boolean(storage.forceLastSavedSpeed);
+        this.settings.disableSnapToOne = Boolean(storage.disableSnapToOne);
         this.settings.audioBoolean = Boolean(storage.audioBoolean);
         this.settings.enabled = Boolean(storage.enabled);
         this.settings.startHidden = Boolean(storage.startHidden);

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -100,6 +100,11 @@
         <em>Prevent video players that override VSC speed</em></label>
       <input id="forceLastSavedSpeed" type="checkbox" />
     </div>
+    <div class="row">
+      <label for="disableSnapToOne">Don't snap to 1.0x<br />
+        <em>Disable snapping to 1.0x when incrementing/decrementing across it</em></label>
+      <input id="disableSnapToOne" type="checkbox" />
+    </div>
     <div class="row advanced-feature">
       <label for="controllerOpacity">Controller opacity</label>
       <input id="controllerOpacity" type="text" value="" />

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -296,6 +296,7 @@ async function save_options() {
 
     var rememberSpeed = document.getElementById("rememberSpeed").checked;
     var forceLastSavedSpeed = document.getElementById("forceLastSavedSpeed").checked;
+    var disableSnapToOne = document.getElementById("disableSnapToOne").checked;
     var audioBoolean = document.getElementById("audioBoolean").checked;
     var startHidden = document.getElementById("startHidden").checked;
     var controllerOpacity = Number(document.getElementById("controllerOpacity").value);
@@ -312,6 +313,7 @@ async function save_options() {
     const settingsToSave = {
       rememberSpeed: rememberSpeed,
       forceLastSavedSpeed: forceLastSavedSpeed,
+      disableSnapToOne: disableSnapToOne,
       audioBoolean: audioBoolean,
       startHidden: startHidden,
       controllerOpacity: controllerOpacity,
@@ -357,6 +359,7 @@ async function restore_options() {
 
     document.getElementById("rememberSpeed").checked = storage.rememberSpeed;
     document.getElementById("forceLastSavedSpeed").checked = storage.forceLastSavedSpeed;
+    document.getElementById("disableSnapToOne").checked = storage.disableSnapToOne;
     document.getElementById("audioBoolean").checked = storage.audioBoolean;
     document.getElementById("startHidden").checked = storage.startHidden;
     document.getElementById("controllerOpacity").value = storage.controllerOpacity;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -22,6 +22,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     displayKeyCode: 86, // default: V
     rememberSpeed: false, // default: false
     forceLastSavedSpeed: false, //default: false
+    disableSnapToOne: false, // default: false (snap to 1.0x when crossing boundary)
     audioBoolean: true, // default: true (enable audio controller support)
     startHidden: false, // default: false
     controllerOpacity: 0.3, // default: 0.3


### PR DESCRIPTION
If going to YouTube and using YouTube's player to increase speed to 1.25x, then watching something on Netflix at same speed, decrementing by 0.1x repeatedly will never get you to 1.0x. This feature will snap to 1.0x if ever crossing the boundary (1.25x->1.15x->1.05x->[snap]1.0x->0.9x->...)

Resetting is also possible but it's convenient to not have to learn a reset hotkey and use only increment/decrement speeds.

The feature can be disabled from the Options area.