### PR TITLE
Buffer logger messages until verbosity is configured

### DIFF
--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -53,9 +53,8 @@ class VideoSpeedExtension {
       this.logger.info('Video Speed Controller initialized successfully');
       this.initialized = true;
     } catch (error) {
-      console.error(`❌ Failed to initialize Video Speed Controller: ${error.message}`);
-      console.error('📋 Full error details:', error);
-      console.error('🔍 Error stack:', error.stack);
+      this.logger.error(`Failed to initialize Video Speed Controller: ${error.message}`);
+      this.logger.error(`Error stack: ${error.stack}`);
     }
   }
 
@@ -242,7 +241,6 @@ class VideoSpeedExtension {
         shouldStartHidden
       );
     } catch (error) {
-      console.error('💥 Failed to attach controller to video:', error);
       this.logger.error(`Failed to attach controller to video: ${error.message}`);
     }
   }
@@ -358,7 +356,6 @@ class VideoSpeedExtension {
 
   // Auto-initialize
   extension.initialize().catch((error) => {
-    console.error(`Extension initialization failed: ${error.message}`);
     window.VSC.logger.error(`Extension initialization failed: ${error.message}`);
   });
 

--- a/src/core/storage-manager.js
+++ b/src/core/storage-manager.js
@@ -71,7 +71,7 @@ if (!window.VSC.StorageManager) {
           chrome.storage.sync.set(data, () => {
             if (chrome.runtime.lastError) {
               const error = new Error(`Storage failed: ${chrome.runtime.lastError.message}`);
-              console.error('Chrome storage save failed:', chrome.runtime.lastError);
+              window.VSC.logger.error(`Chrome storage save failed: ${chrome.runtime.lastError.message}`);
 
               // Call error callback if registered (for monitoring/telemetry)
               if (this.errorCallback) {
@@ -114,7 +114,7 @@ if (!window.VSC.StorageManager) {
           chrome.storage.sync.remove(keys, () => {
             if (chrome.runtime.lastError) {
               const error = new Error(`Storage remove failed: ${chrome.runtime.lastError.message}`);
-              console.error('Chrome storage remove failed:', chrome.runtime.lastError);
+              window.VSC.logger.error(`Chrome storage remove failed: ${chrome.runtime.lastError.message}`);
 
               // Call error callback if registered (for monitoring/telemetry)
               if (this.errorCallback) {
@@ -147,7 +147,7 @@ if (!window.VSC.StorageManager) {
           chrome.storage.sync.clear(() => {
             if (chrome.runtime.lastError) {
               const error = new Error(`Storage clear failed: ${chrome.runtime.lastError.message}`);
-              console.error('Chrome storage clear failed:', chrome.runtime.lastError);
+              window.VSC.logger.error(`Chrome storage clear failed: ${chrome.runtime.lastError.message}`);
 
               // Call error callback if registered (for monitoring/telemetry)
               if (this.errorCallback) {

--- a/src/entries/content-entry.js
+++ b/src/entries/content-entry.js
@@ -12,13 +12,11 @@ async function init() {
 
     // Early exit if extension is disabled
     if (settings.enabled === false) {
-      console.debug('[VSC] Extension disabled');
       return;
     }
 
     // Early exit if site is blacklisted
     if (isBlacklisted(settings.blacklist, location.href)) {
-      console.debug('[VSC] Site blacklisted');
       return;
     }
 
@@ -39,7 +37,6 @@ async function init() {
     // Set up bi-directional message bridge for popup ↔ page communication
     setupMessageBridge();
 
-    console.debug('[VSC] Content script initialized');
   } catch (error) {
     console.error('[VSC] Failed to initialize:', error);
   }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -10,14 +10,25 @@ if (!window.VSC.logger) {
       this.verbosity = 3; // Default warning level
       this.defaultLevel = 4; // Default info level
       this.contextStack = []; // Stack for nested contexts
+      this._buffer = []; // Holds messages logged before verbosity is configured
+      this._ready = false; // True once setVerbosity() has been called with user prefs
     }
 
     /**
-     * Set logging verbosity level
+     * Set logging verbosity level and flush any buffered messages.
+     * Called once config.load() has the user's logLevel preference.
      * @param {number} level - Log level from LOG_LEVELS constants
      */
     setVerbosity(level) {
       this.verbosity = level;
+      if (!this._ready) {
+        this._ready = true;
+        const pending = this._buffer;
+        this._buffer = [];
+        for (const entry of pending) {
+          this._emit(entry.message, entry.level);
+        }
+      }
     }
 
     /**
@@ -102,32 +113,47 @@ if (!window.VSC.logger) {
      */
     log(message, level) {
       const logLevel = typeof level === 'undefined' ? this.defaultLevel : level;
-      const LOG_LEVELS = window.VSC.Constants.LOG_LEVELS;
 
-      if (this.verbosity >= logLevel) {
-        const context = this.generateContext();
-        const contextualMessage = `${context}${message}`;
-        
-        switch (logLevel) {
-          case LOG_LEVELS.ERROR:
-            console.log(`ERROR:${contextualMessage}`);
-            break;
-          case LOG_LEVELS.WARNING:
-            console.log(`WARNING:${contextualMessage}`);
-            break;
-          case LOG_LEVELS.INFO:
-            console.log(`INFO:${contextualMessage}`);
-            break;
-          case LOG_LEVELS.DEBUG:
-            console.log(`DEBUG:${contextualMessage}`);
-            break;
-          case LOG_LEVELS.VERBOSE:
-            console.log(`DEBUG (VERBOSE):${contextualMessage}`);
-            console.trace();
-            break;
-          default:
-            console.log(contextualMessage);
-        }
+      if (!this._ready) {
+        this._buffer.push({ message, level: logLevel });
+        return;
+      }
+
+      this._emit(message, logLevel);
+    }
+
+    /**
+     * Emit a log message to console (only called after verbosity is configured)
+     * @param {string} message - Message to log
+     * @param {number} logLevel - Resolved log level
+     * @private
+     */
+    _emit(message, logLevel) {
+      if (this.verbosity < logLevel) return;
+
+      const LOG_LEVELS = window.VSC.Constants.LOG_LEVELS;
+      const context = this.generateContext();
+      const contextualMessage = `${context}${message}`;
+
+      switch (logLevel) {
+        case LOG_LEVELS.ERROR:
+          console.log(`ERROR:${contextualMessage}`);
+          break;
+        case LOG_LEVELS.WARNING:
+          console.log(`WARNING:${contextualMessage}`);
+          break;
+        case LOG_LEVELS.INFO:
+          console.log(`INFO:${contextualMessage}`);
+          break;
+        case LOG_LEVELS.DEBUG:
+          console.log(`DEBUG:${contextualMessage}`);
+          break;
+        case LOG_LEVELS.VERBOSE:
+          console.log(`DEBUG (VERBOSE):${contextualMessage}`);
+          console.trace();
+          break;
+        default:
+          console.log(contextualMessage);
       }
     }
 

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -145,6 +145,7 @@ async function runTests() {
       'unit/utils/recursive-shadow-dom.test.js',
       'unit/utils/blacklist-regex.test.js',
       'unit/utils/event-manager.test.js',
+      'unit/utils/logger.test.js',
       'unit/content/injection-bridge.test.js'
     ];
   } else if (testType === 'integration') {
@@ -172,6 +173,7 @@ async function runTests() {
       'unit/utils/recursive-shadow-dom.test.js',
       'unit/utils/blacklist-regex.test.js',
       'unit/utils/event-manager.test.js',
+      'unit/utils/logger.test.js',
       'integration/module-integration.test.js',
       'integration/ui-to-storage-flow.test.js',
       'integration/state-manager-integration.test.js',

--- a/tests/unit/utils/logger.test.js
+++ b/tests/unit/utils/logger.test.js
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for logger buffering behavior
+ * Verifies messages are buffered until setVerbosity() configures the logger
+ */
+
+import { SimpleTestRunner, assert } from '../../helpers/test-utils.js';
+
+const LOG_LEVELS = window.VSC.Constants.LOG_LEVELS;
+
+/**
+ * Create a fresh Logger instance for testing by resetting the singleton's state
+ */
+function createLogger() {
+  const logger = window.VSC.logger;
+  // Reset to pre-configured state
+  logger.verbosity = 3;
+  logger.defaultLevel = 4;
+  logger.contextStack = [];
+  logger._buffer = [];
+  logger._ready = false;
+  return logger;
+}
+
+/** Capture console.log calls */
+function captureConsole() {
+  const calls = [];
+  const originalLog = console.log;
+  const originalTrace = console.trace;
+  console.log = (...args) => calls.push(args.join(' '));
+  console.trace = () => {}; // suppress trace noise in tests
+  return {
+    calls,
+    restore: () => {
+      console.log = originalLog;
+      console.trace = originalTrace;
+    }
+  };
+}
+
+const runner = new SimpleTestRunner();
+
+runner.test('logger buffers messages before setVerbosity is called', () => {
+  const logger = createLogger();
+  logger.log('early message', LOG_LEVELS.INFO);
+  logger.log('another early', LOG_LEVELS.ERROR);
+
+  assert.equal(logger._buffer.length, 2, 'Should have 2 buffered messages');
+  assert.equal(logger._ready, false, 'Should not be ready yet');
+});
+
+runner.test('setVerbosity flushes buffered messages that pass the filter', () => {
+  const logger = createLogger();
+  const capture = captureConsole();
+
+  try {
+    // Buffer: one INFO (level 4) and one ERROR (level 2)
+    logger.log('info msg', LOG_LEVELS.INFO);
+    logger.log('error msg', LOG_LEVELS.ERROR);
+
+    assert.equal(capture.calls.length, 0, 'Nothing emitted before setVerbosity');
+
+    // Set verbosity to WARNING (3) — should emit ERROR but not INFO
+    logger.setVerbosity(LOG_LEVELS.WARNING);
+
+    assert.equal(logger._ready, true, 'Should be ready after setVerbosity');
+    assert.equal(logger._buffer.length, 0, 'Buffer should be drained');
+    assert.equal(capture.calls.length, 1, 'Only ERROR should have been emitted');
+    assert.true(capture.calls[0].includes('error msg'), 'Emitted message should be the error');
+  } finally {
+    capture.restore();
+  }
+});
+
+runner.test('setVerbosity flushes all messages when verbosity is high', () => {
+  const logger = createLogger();
+  const capture = captureConsole();
+
+  try {
+    logger.log('debug msg', LOG_LEVELS.DEBUG);
+    logger.log('info msg', LOG_LEVELS.INFO);
+    logger.log('error msg', LOG_LEVELS.ERROR);
+
+    logger.setVerbosity(LOG_LEVELS.DEBUG);
+
+    assert.equal(capture.calls.length, 3, 'All 3 messages should be emitted at DEBUG verbosity');
+  } finally {
+    capture.restore();
+  }
+});
+
+runner.test('after setVerbosity, messages emit immediately (no buffering)', () => {
+  const logger = createLogger();
+  const capture = captureConsole();
+
+  try {
+    logger.setVerbosity(LOG_LEVELS.INFO);
+
+    logger.log('direct message', LOG_LEVELS.INFO);
+    assert.equal(capture.calls.length, 1, 'Message should emit immediately');
+    assert.equal(logger._buffer.length, 0, 'Buffer should remain empty');
+  } finally {
+    capture.restore();
+  }
+});
+
+runner.test('subsequent setVerbosity calls do not re-flush', () => {
+  const logger = createLogger();
+  const capture = captureConsole();
+
+  try {
+    logger.log('buffered', LOG_LEVELS.ERROR);
+    logger.setVerbosity(LOG_LEVELS.WARNING); // first call — flushes
+
+    const countAfterFirst = capture.calls.length;
+    logger.setVerbosity(LOG_LEVELS.DEBUG); // second call — should NOT re-flush
+
+    assert.equal(capture.calls.length, countAfterFirst, 'No additional messages from second setVerbosity');
+  } finally {
+    capture.restore();
+  }
+});
+
+runner.test('convenience methods (error, warn, info, debug) buffer correctly', () => {
+  const logger = createLogger();
+
+  logger.error('e');
+  logger.warn('w');
+  logger.info('i');
+  logger.debug('d');
+
+  assert.equal(logger._buffer.length, 4, 'All 4 convenience methods should buffer');
+  assert.equal(logger._buffer[0].level, LOG_LEVELS.ERROR, 'error() uses ERROR level');
+  assert.equal(logger._buffer[1].level, LOG_LEVELS.WARNING, 'warn() uses WARNING level');
+  assert.equal(logger._buffer[2].level, LOG_LEVELS.INFO, 'info() uses INFO level');
+  assert.equal(logger._buffer[3].level, LOG_LEVELS.DEBUG, 'debug() uses DEBUG level');
+});
+
+export { runner };


### PR DESCRIPTION
The logger was emitting messages before config.load() set the user's
preferred log level, causing unwanted console noise. Now the logger
buffers all messages until setVerbosity() is called, then flushes
through the configured filter.

Also consolidates all page-context logging through the logger:
- inject.js: remove dual console.error + logger.error pattern
- storage-manager.js: replace console.error with logger.error
- content-entry.js: guard console.debug with logLevel from settings