### PR TITLE
Simplify: merge forceLastSavedSpeed into fight detection

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -401,25 +401,20 @@ class ActionHandler {
     // Round to 2 decimal places to avoid floating point issues
     targetSpeed = Number(targetSpeed.toFixed(2));
 
-    // Handle force mode for external changes - restore user preference
-    if (source === 'external' && this.config.settings.forceLastSavedSpeed) {
-      // In force mode, use lastSpeed instead of allowing external change
-      targetSpeed = this.config.settings.lastSpeed || 1.0;
-      window.VSC.logger.debug(`Force mode: blocking external change, restoring to ${targetSpeed}`);
-    }
-
-    // Use the proven setSpeed implementation with source tracking
+    // Note: forceLastSavedSpeed is enforced upstream in fight detection (event-manager.js).
+    // External changes that reach here have already been approved (fight surrendered or speed matched).
     this.setSpeed(video, targetSpeed, source);
   }
 
   /**
-   * Get user's preferred speed (always global lastSpeed)
-   * Public method for tests - matches VideoController.getTargetSpeed() logic
-   * @param {HTMLMediaElement} video - Video element (for API compatibility) 
-   * @returns {number} Current preferred speed (always lastSpeed regardless of rememberSpeed setting)
+   * Get user's preferred speed, respecting rememberSpeed setting.
+   * @returns {number} Preferred speed (lastSpeed when remembering, 1.0 otherwise)
    */
   getPreferredSpeed() {
-    return this.config.settings.lastSpeed || 1.0;
+    if (this.config.settings.rememberSpeed) {
+      return this.config.settings.lastSpeed || 1.0;
+    }
+    return 1.0;
   }
 
   /**
@@ -466,14 +461,15 @@ class ActionHandler {
     }
     speedIndicator.textContent = numericSpeed.toFixed(2);
 
-    // 5. Always update page-scoped speed preference
-    this.config.settings.lastSpeed = numericSpeed;
+    // 5. Update lastSpeed only for user-initiated changes — external/site
+    //    speed overrides must not corrupt the user's intended speed.
+    if (source !== 'external') {
+      this.config.settings.lastSpeed = numericSpeed;
 
-    // 6. Save to storage ONLY if rememberSpeed is enabled for cross-session persistence
-    if (this.config.settings.rememberSpeed) {
-      this.config.save({
-        lastSpeed: this.config.settings.lastSpeed,
-      });
+      // 6. Persist to storage only if rememberSpeed is enabled
+      if (this.config.settings.rememberSpeed) {
+        this.config.save({ lastSpeed: numericSpeed });
+      }
     }
 
     // 7. Show controller briefly for visual feedback

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -67,23 +67,21 @@ class VideoController {
   }
 
   /**
-   * Get target speed based on rememberSpeed setting and update reset binding
-   * @param {HTMLMediaElement} media - Optional media element (defaults to this.video)
+   * Get target speed for video initialization and event restoration.
+   * When rememberSpeed is on, resume from persisted lastSpeed.
+   * When off, start fresh at 1.0 — the user opted out of persistence.
    * @returns {number} Target speed
    * @private
    */
   getTargetSpeed() {
-    // Always start with current preferred speed (lastSpeed)
-    // The difference is whether changes get saved back to lastSpeed
-    const targetSpeed = this.config.settings.lastSpeed || 1.0;
-
     if (this.config.settings.rememberSpeed) {
-      window.VSC.logger.debug(`Remember mode: using lastSpeed ${targetSpeed} (changes will be saved)`);
-    } else {
-      window.VSC.logger.debug(`Non-persistent mode: using lastSpeed ${targetSpeed} (changes won't be saved)`);
+      const targetSpeed = this.config.settings.lastSpeed || 1.0;
+      window.VSC.logger.debug(`Remember mode: using lastSpeed ${targetSpeed}`);
+      return targetSpeed;
     }
 
-    return targetSpeed;
+    window.VSC.logger.debug('Non-persistent mode: starting at 1.0');
+    return 1.0;
   }
 
   /**

--- a/src/utils/event-manager.js
+++ b/src/utils/event-manager.js
@@ -205,15 +205,6 @@ class EventManager {
       return;
     }
 
-    // Force last saved speed mode — restore authoritative speed for ANY external change
-    if (this.config.settings.forceLastSavedSpeed) {
-      const authoritativeSpeed = this.config.settings.lastSpeed || 1.0;
-      window.VSC.logger.info(`Force mode: restoring external ${video.playbackRate} to authoritative ${authoritativeSpeed}`);
-      video.playbackRate = authoritativeSpeed;
-      event.stopImmediatePropagation();
-      return;
-    }
-
     // Ignore external ratechanges during video initialization
     if (video.readyState < 1) {
       window.VSC.logger.debug('Ignoring external ratechange during video initialization (readyState < 1)');
@@ -221,10 +212,8 @@ class EventManager {
       return;
     }
 
-    // External change
-    const rawExternalRate = typeof video.playbackRate === 'number' ? video.playbackRate : NaN;
-
     // Ignore spurious external ratechanges below our supported MIN
+    const rawExternalRate = typeof video.playbackRate === 'number' ? video.playbackRate : NaN;
     const min = window.VSC.Constants.SPEED_LIMITS.MIN;
     if (!isNaN(rawExternalRate) && rawExternalRate <= min) {
       window.VSC.logger.debug(
@@ -234,8 +223,13 @@ class EventManager {
       return;
     }
 
-    // Fight detection: if site changed speed away from what we set, fight back
+    // Fight detection: if site changed speed away from what we set, fight back.
+    // forceLastSavedSpeed = fight forever (Infinity retries); otherwise surrender after MAX_FIGHT_COUNT.
     const authoritativeSpeed = this.config.settings.lastSpeed;
+    const maxRetries = this.config.settings.forceLastSavedSpeed
+      ? Infinity
+      : EventManager.MAX_FIGHT_COUNT;
+
     if (authoritativeSpeed && Math.abs(video.playbackRate - authoritativeSpeed) > 0.01) {
       this.fightCount++;
 
@@ -246,7 +240,7 @@ class EventManager {
         this.fightTimer = null;
       }, EventManager.FIGHT_WINDOW_MS);
 
-      if (this.fightCount > EventManager.MAX_FIGHT_COUNT) {
+      if (this.fightCount > maxRetries) {
         // Surrender — accept the site's speed
         window.VSC.logger.info(
           `Fight detection: surrendering after ${this.fightCount} resets. Accepting site speed ${video.playbackRate}`
@@ -256,7 +250,7 @@ class EventManager {
       } else {
         // Fight back — restore our speed
         window.VSC.logger.info(
-          `Fight detection: attempt ${this.fightCount}/${EventManager.MAX_FIGHT_COUNT}, re-applying ${authoritativeSpeed}`
+          `Fight detection: attempt ${this.fightCount}/${maxRetries}, re-applying ${authoritativeSpeed}`
         );
         video.playbackRate = authoritativeSpeed;
         this.refreshCoolDown();


### PR DESCRIPTION
forceLastSavedSpeed is conceptually fight detection with infinite
patience. Unify them into one code path with a configurable
maxRetries (Infinity for force mode, 3 for normal mode).

Removes the separate forceLastSavedSpeed early-return block in
handleRateChange and the duplicate (unreachable) force check in
_adjustSpeedInternal.