### PR TITLE
Fix #1370: tear down controllers when site is blacklisted at runtime

### DIFF
--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -246,6 +246,44 @@ class VideoSpeedExtension {
   }
 
   /**
+   * Tear down the extension: remove all controllers, stop observers, clean up listeners.
+   * Counterpart to initialize() — leaves the page as if VSC was never active.
+   */
+  teardown() {
+    if (!this.initialized) return;
+
+    this.logger.info('Tearing down Video Speed Controller');
+
+    // Remove all controllers from tracked media elements
+    const videos = window.VSC.stateManager ? window.VSC.stateManager.getAllMediaElements() : [];
+    for (const video of videos) {
+      if (video.vsc) video.vsc.remove();
+    }
+
+    // Stop observing DOM for new videos
+    if (this.mutationObserver) {
+      this.mutationObserver.stop();
+      this.mutationObserver = null;
+    }
+
+    // Remove keyboard/ratechange listeners
+    if (this.eventManager) {
+      this.eventManager.cleanup();
+      this.eventManager = null;
+    }
+
+    // Clean up site-specific handlers
+    if (this.siteHandlerManager) {
+      this.siteHandlerManager.cleanup();
+    }
+
+    this.actionHandler = null;
+    this.mediaObserver = null;
+    this.initialized = false;
+    window.VSC.initialized = false;
+  }
+
+  /**
    * Handle removed video element
    * @param {HTMLMediaElement} video - Video element
    */
@@ -343,6 +381,14 @@ class VideoSpeedExtension {
           if (extension.actionHandler) {
             extension.actionHandler.runAction('display', null, null);
           }
+          break;
+
+        case window.VSC.Constants.MESSAGE_TYPES.TEARDOWN:
+          extension.teardown();
+          break;
+
+        case window.VSC.Constants.MESSAGE_TYPES.REINIT:
+          extension.initialize();
           break;
       }
     }

--- a/src/content/injection-bridge.js
+++ b/src/content/injection-bridge.js
@@ -27,7 +27,7 @@ export async function injectScript(scriptPath) {
 /**
  * Set up message bridge between content script and page context.
  * Handles bi-directional communication for popup and settings updates.
- * @returns {Function} cleanup - Call to remove all listeners (useful for tests)
+ * @returns {{ sendCommand: (type: string, payload?: any) => void, cleanup: () => void }}
  */
 export function setupMessageBridge() {
   // Named function so we can remove it on context invalidation
@@ -103,10 +103,17 @@ export function setupMessageBridge() {
   }
   chrome.storage.onChanged.addListener(handleStorageChanged);
 
-  // Return cleanup function for teardown (tests, extension unload)
-  return () => {
-    window.removeEventListener('message', handlePageMessage);
-    chrome.runtime.onMessage.removeListener?.(handleRuntimeMessage);
-    chrome.storage.onChanged.removeListener?.(handleStorageChanged);
+  return {
+    /** Send a command to the page context via the same channel popup messages use. */
+    sendCommand(type, payload) {
+      window.dispatchEvent(new CustomEvent('VSC_MESSAGE', { detail: { type, payload } }));
+    },
+
+    /** Remove all listeners (tests, extension unload). */
+    cleanup() {
+      window.removeEventListener('message', handlePageMessage);
+      chrome.runtime.onMessage.removeListener?.(handleRuntimeMessage);
+      chrome.storage.onChanged.removeListener?.(handleStorageChanged);
+    },
   };
 }

--- a/src/entries/content-entry.js
+++ b/src/entries/content-entry.js
@@ -35,7 +35,31 @@ async function init() {
     await injectScript('inject.js');
 
     // Set up bi-directional message bridge for popup ↔ page communication
-    setupMessageBridge();
+    const bridge = setupMessageBridge();
+
+    // Lifecycle watcher: tear down or reinit when blacklist/enabled changes.
+    // The content script is the lifecycle owner — it gates initialization above,
+    // and it gates teardown/reinit here, using the same bridge the popup uses for commands.
+    chrome.storage.onChanged.addListener((changes, namespace) => {
+      if (namespace !== 'sync') return;
+
+      const disabled = 'enabled' in changes && changes.enabled.newValue === false;
+      const blacklisted = 'blacklist' in changes &&
+        isBlacklisted(changes.blacklist.newValue, location.href);
+
+      if (disabled || blacklisted) {
+        bridge.sendCommand('VSC_TEARDOWN');
+        return;
+      }
+
+      const reEnabled = 'enabled' in changes && changes.enabled.newValue === true;
+      const unblacklisted = 'blacklist' in changes &&
+        !isBlacklisted(changes.blacklist.newValue, location.href);
+
+      if (reEnabled || unblacklisted) {
+        bridge.sendCommand('VSC_REINIT');
+      }
+    });
 
   } catch (error) {
     console.error('[VSC] Failed to initialize:', error);

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -69,6 +69,8 @@ meet.google.com`.replace(regStrip, ''),
     ADJUST_SPEED: 'VSC_ADJUST_SPEED',
     RESET_SPEED: 'VSC_RESET_SPEED',
     TOGGLE_DISPLAY: 'VSC_TOGGLE_DISPLAY',
+    TEARDOWN: 'VSC_TEARDOWN',
+    REINIT: 'VSC_REINIT',
   };
 
   const SPEED_LIMITS = {

--- a/tests/unit/content/content-entry.test.js
+++ b/tests/unit/content/content-entry.test.js
@@ -75,4 +75,115 @@ runner.test('enabled extension on non-blacklisted site should proceed', () => {
   assert.equal(keys.includes('lastSpeed'), true, 'lastSpeed should remain');
 });
 
+// --- Lifecycle watcher logic (mirrors content-entry.js storage.onChanged handler) ---
+
+runner.test('blacklist change matching current site should trigger teardown', () => {
+  // Simulate the logic in content-entry.js onChanged handler
+  const currentHref = 'https://www.youtube.com/watch?v=123';
+  const changes = {
+    blacklist: { newValue: 'youtube.com\nnetflix.com' }
+  };
+
+  const nowBlacklisted = 'blacklist' in changes &&
+    isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.true(nowBlacklisted, 'should detect site is now blacklisted');
+});
+
+runner.test('blacklist change NOT matching current site should not trigger teardown', () => {
+  const currentHref = 'https://www.example.com/page';
+  const changes = {
+    blacklist: { newValue: 'youtube.com\nnetflix.com' }
+  };
+
+  const nowBlacklisted = 'blacklist' in changes &&
+    isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.false(nowBlacklisted, 'should not trigger teardown for unrelated site');
+});
+
+runner.test('enabled=false change should trigger teardown', () => {
+  const changes = {
+    enabled: { newValue: false }
+  };
+
+  const nowDisabled = 'enabled' in changes && changes.enabled.newValue === false;
+
+  assert.true(nowDisabled, 'should detect extension is now disabled');
+});
+
+runner.test('enabled=true change should not trigger teardown', () => {
+  const changes = {
+    enabled: { newValue: true }
+  };
+
+  const nowDisabled = 'enabled' in changes && changes.enabled.newValue === false;
+
+  assert.false(nowDisabled, 'should not trigger teardown when re-enabled');
+});
+
+runner.test('unrelated storage change should not trigger teardown', () => {
+  const currentHref = 'https://www.example.com/page';
+  const changes = {
+    lastSpeed: { newValue: 2.5 }
+  };
+
+  const nowDisabled = 'enabled' in changes && changes.enabled.newValue === false;
+  const nowBlacklisted = 'blacklist' in changes &&
+    isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.false(nowDisabled, 'speed change should not disable');
+  assert.false(nowBlacklisted, 'speed change should not blacklist');
+});
+
+// --- Reinit logic (mirrors content-entry.js storage.onChanged handler) ---
+
+runner.test('enabled=true change should trigger reinit', () => {
+  const changes = {
+    enabled: { newValue: true }
+  };
+
+  const reEnabled = 'enabled' in changes && changes.enabled.newValue === true;
+
+  assert.true(reEnabled, 'should detect extension was re-enabled');
+});
+
+runner.test('site removed from blacklist should trigger reinit', () => {
+  const currentHref = 'https://www.youtube.com/watch?v=123';
+  const changes = {
+    blacklist: { newValue: 'netflix.com' }  // youtube removed from list
+  };
+
+  const unblacklisted = 'blacklist' in changes &&
+    !isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.true(unblacklisted, 'should detect site is no longer blacklisted');
+});
+
+runner.test('blacklist change that still includes current site should not trigger reinit', () => {
+  const currentHref = 'https://www.youtube.com/watch?v=123';
+  const changes = {
+    blacklist: { newValue: 'youtube.com\nnetflix.com' }
+  };
+
+  const unblacklisted = 'blacklist' in changes &&
+    !isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.false(unblacklisted, 'should not reinit when site is still blacklisted');
+});
+
+runner.test('unrelated storage change should not trigger reinit', () => {
+  const currentHref = 'https://www.example.com/page';
+  const changes = {
+    lastSpeed: { newValue: 2.5 }
+  };
+
+  const reEnabled = 'enabled' in changes && changes.enabled.newValue === true;
+  const unblacklisted = 'blacklist' in changes &&
+    !isBlacklisted(changes.blacklist.newValue, currentHref);
+
+  assert.false(reEnabled, 'speed change should not re-enable');
+  assert.false(unblacklisted, 'speed change should not un-blacklist');
+});
+
 export { runner };

--- a/tests/unit/content/injection-bridge.test.js
+++ b/tests/unit/content/injection-bridge.test.js
@@ -8,7 +8,7 @@ import { SimpleTestRunner, assert, wait } from '../../helpers/test-utils.js';
 import { setupMessageBridge } from '../../../src/content/injection-bridge.js';
 
 const runner = new SimpleTestRunner();
-let cleanup;
+let bridge;
 
 runner.beforeEach(() => {
   installChromeMock();
@@ -17,8 +17,8 @@ runner.beforeEach(() => {
 });
 
 runner.afterEach(() => {
-  if (cleanup) cleanup();
-  cleanup = null;
+  if (bridge) bridge.cleanup();
+  bridge = null;
   cleanupChromeMock();
 });
 
@@ -40,7 +40,7 @@ runner.test('storage-update forwards to chrome.storage.sync.set', async () => {
   let setData = null;
   chrome.storage.sync.set = (data) => { setData = data; };
 
-  cleanup = setupMessageBridge();
+  bridge = setupMessageBridge();
   postPageMessage('storage-update', { lastSpeed: 2.5 });
   await wait(20);
 
@@ -52,7 +52,7 @@ runner.test('runtime-message filters out VSC_STATE_UPDATE', async () => {
   let sendCalled = false;
   chrome.runtime.sendMessage = () => { sendCalled = true; };
 
-  cleanup = setupMessageBridge();
+  bridge = setupMessageBridge();
   postPageMessage('runtime-message', { type: 'VSC_STATE_UPDATE' });
   await wait(20);
 
@@ -66,7 +66,7 @@ runner.test('Extension context invalidated removes the message listener', async 
     throw new Error('Extension context invalidated');
   };
 
-  cleanup = setupMessageBridge();
+  bridge = setupMessageBridge();
 
   // First message triggers invalidation — listener should self-remove
   postPageMessage('storage-update', { lastSpeed: 2.0 });
@@ -89,7 +89,7 @@ runner.test('non-invalidation errors keep the listener alive', async () => {
     if (callCount === 1) throw new Error('QUOTA_BYTES_PER_ITEM quota exceeded');
   };
 
-  cleanup = setupMessageBridge();
+  bridge = setupMessageBridge();
 
   // First message throws quota error — listener should survive
   postPageMessage('storage-update', { lastSpeed: 2.0 });
@@ -100,6 +100,38 @@ runner.test('non-invalidation errors keep the listener alive', async () => {
   await wait(20);
 
   assert.equal(callCount, 2, 'listener should still be active after non-invalidation error');
+});
+
+// --- sendCommand API ---
+
+runner.test('sendCommand dispatches VSC_MESSAGE CustomEvent to page context', async () => {
+  bridge = setupMessageBridge();
+
+  let received = null;
+  window.addEventListener('VSC_MESSAGE', (event) => {
+    received = event.detail;
+  }, { once: true });
+
+  bridge.sendCommand('VSC_TEARDOWN');
+  await wait(20);
+
+  assert.exists(received, 'VSC_MESSAGE event should have been dispatched');
+  assert.equal(received.type, 'VSC_TEARDOWN', 'type should match');
+});
+
+runner.test('sendCommand includes payload when provided', async () => {
+  bridge = setupMessageBridge();
+
+  let received = null;
+  window.addEventListener('VSC_MESSAGE', (event) => {
+    received = event.detail;
+  }, { once: true });
+
+  bridge.sendCommand('VSC_SET_SPEED', { speed: 2.0 });
+  await wait(20);
+
+  assert.exists(received, 'VSC_MESSAGE event should have been dispatched');
+  assert.equal(received.payload.speed, 2.0, 'payload should be forwarded');
 });
 
 export { runner as injectionBridgeTestRunner };


### PR DESCRIPTION
The blacklist check (moved to content script in 2a9b0e4) only ran once
at page load. If a user added a site to the blacklist while the tab was
already open, the controller stayed visible until a full page reload.

Add a chrome.storage.onChanged listener in the content script that
re-evaluates the blacklist/enabled state and dispatches a VSC_TEARDOWN
event to the page context, which removes all controllers and stops
observers.

Note: this is a tactical fix — a cleaner approach would route through
the existing message bridge and add a first-class teardown() method on
VideoSpeedExtension.