### PR TITLE
Unify drag handling for mouse+touch and add double-click to reset speed

### DIFF
--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -23,17 +23,31 @@ class ControlsManager {
   }
 
   /**
-   * Set up drag handler for speed indicator
+   * Set up drag and double-click-to-reset handlers for speed indicator
+   * Uses pointer events for unified mouse + touch support
    * @param {ShadowRoot} shadow - Shadow root
    * @private
    */
   setupDragHandler(shadow) {
     const draggable = shadow.querySelector('.draggable');
 
+    // Pointer-based drag (unified mouse + touch)
     draggable.addEventListener(
-      'mousedown',
+      'pointerdown',
       (e) => {
         this.actionHandler.runAction(e.target.dataset['action'], false, e);
+        e.stopPropagation();
+        e.preventDefault();
+      },
+      true
+    );
+
+    // Double-click / double-tap to reset speed
+    draggable.addEventListener(
+      'dblclick',
+      (e) => {
+        const resetTarget = this.config.getKeyBinding('reset') || 1.0;
+        this.actionHandler.runAction('reset', resetTarget, e);
         e.stopPropagation();
         e.preventDefault();
       },

--- a/src/ui/drag-handler.js
+++ b/src/ui/drag-handler.js
@@ -1,44 +1,50 @@
 /**
  * Drag functionality for video controller
+ * Uses pointer events for unified mouse + touch support
  */
 
 window.VSC = window.VSC || {};
 
 class DragHandler {
   /**
-   * Handle dragging of video controller
+   * Handle dragging of video controller via pointer events
    * @param {HTMLVideoElement} video - Video element
-   * @param {MouseEvent} e - Mouse event
+   * @param {PointerEvent|MouseEvent} e - Pointer/mouse event
    */
   static handleDrag(video, e) {
     const controller = video.vsc.div;
     const shadowController = controller.shadowRoot.querySelector('#controller');
 
-    // Find nearest parent of same size as video parent
-    const parentElement = window.VSC.DomUtils.findVideoParent(controller);
-
     video.classList.add('vcs-dragging');
     shadowController.classList.add('dragging');
 
-    const initialMouseXY = [e.clientX, e.clientY];
+    const initialXY = [e.clientX, e.clientY];
     const initialControllerXY = [
       parseInt(shadowController.style.left) || 0,
       parseInt(shadowController.style.top) || 0,
     ];
 
-    const startDragging = (e) => {
-      const style = shadowController.style;
-      const dx = e.clientX - initialMouseXY[0];
-      const dy = e.clientY - initialMouseXY[1];
+    const draggable = e.target;
 
-      style.left = `${initialControllerXY[0] + dx}px`;
-      style.top = `${initialControllerXY[1] + dy}px`;
+    // Capture pointer so all move/up events route here regardless of position
+    if (e.pointerId !== undefined) {
+      draggable.setPointerCapture(e.pointerId);
+    }
+
+    const onMove = (ev) => {
+      const dx = ev.clientX - initialXY[0];
+      const dy = ev.clientY - initialXY[1];
+      shadowController.style.left = `${initialControllerXY[0] + dx}px`;
+      shadowController.style.top = `${initialControllerXY[1] + dy}px`;
     };
 
-    const stopDragging = () => {
-      parentElement.removeEventListener('mousemove', startDragging);
-      parentElement.removeEventListener('mouseup', stopDragging);
-      parentElement.removeEventListener('mouseleave', stopDragging);
+    const onEnd = () => {
+      draggable.removeEventListener('pointermove', onMove);
+      draggable.removeEventListener('pointerup', onEnd);
+      draggable.removeEventListener('pointercancel', onEnd);
+      // Mouse fallbacks
+      draggable.removeEventListener('mousemove', onMove);
+      draggable.removeEventListener('mouseup', onEnd);
 
       shadowController.classList.remove('dragging');
       video.classList.remove('vcs-dragging');
@@ -46,9 +52,15 @@ class DragHandler {
       window.VSC.logger.debug('Drag operation completed');
     };
 
-    parentElement.addEventListener('mouseup', stopDragging);
-    parentElement.addEventListener('mouseleave', stopDragging);
-    parentElement.addEventListener('mousemove', startDragging);
+    if (e.pointerId !== undefined) {
+      draggable.addEventListener('pointermove', onMove);
+      draggable.addEventListener('pointerup', onEnd);
+      draggable.addEventListener('pointercancel', onEnd);
+    } else {
+      // Fallback for environments without pointer events
+      draggable.addEventListener('mousemove', onMove);
+      draggable.addEventListener('mouseup', onEnd);
+    }
 
     window.VSC.logger.debug('Drag operation started');
   }

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -97,6 +97,7 @@ class ShadowDOMManager {
         text-align: center;
         vertical-align: middle;
         box-sizing: border-box;
+        touch-action: none;
       }
       
       .draggable:active {

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -146,6 +146,7 @@ async function runTests() {
       'unit/utils/blacklist-regex.test.js',
       'unit/utils/event-manager.test.js',
       'unit/utils/logger.test.js',
+      'unit/ui/drag-and-reset.test.js',
       'unit/content/injection-bridge.test.js'
     ];
   } else if (testType === 'integration') {
@@ -174,6 +175,7 @@ async function runTests() {
       'unit/utils/blacklist-regex.test.js',
       'unit/utils/event-manager.test.js',
       'unit/utils/logger.test.js',
+      'unit/ui/drag-and-reset.test.js',
       'integration/module-integration.test.js',
       'integration/ui-to-storage-flow.test.js',
       'integration/state-manager-integration.test.js',

--- a/tests/unit/ui/drag-and-reset.test.js
+++ b/tests/unit/ui/drag-and-reset.test.js
@@ -1,0 +1,155 @@
+/**
+ * Tests for unified pointer-based drag and double-click-to-reset
+ */
+
+import { installChromeMock, cleanupChromeMock, resetMockStorage } from '../../helpers/chrome-mock.js';
+import { SimpleTestRunner, assert, createMockVideo, createMockDOM } from '../../helpers/test-utils.js';
+import { loadCoreModules } from '../../helpers/module-loader.js';
+
+await loadCoreModules();
+
+const runner = new SimpleTestRunner();
+let mockDOM;
+
+runner.beforeEach(() => {
+  installChromeMock();
+  resetMockStorage();
+  mockDOM = createMockDOM();
+
+  if (window.VSC && window.VSC.stateManager) {
+    window.VSC.stateManager.controllers.clear();
+  }
+  if (window.VSC && window.VSC.siteHandlerManager) {
+    window.VSC.siteHandlerManager.initialize(document);
+  }
+});
+
+runner.afterEach(() => {
+  cleanupChromeMock();
+  if (window.VSC && window.VSC.stateManager) {
+    window.VSC.stateManager.controllers.clear();
+  }
+  document.querySelectorAll('video, audio').forEach(el => el.remove());
+  if (mockDOM) {
+    mockDOM.cleanup();
+  }
+});
+
+// --- DragHandler tests ---
+
+runner.test('DragHandler.handleDrag uses pointer capture when pointerId is present', async () => {
+  const config = window.VSC.videoSpeedConfig;
+  await config.load();
+  const eventManager = new window.VSC.EventManager(config, null);
+  const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+  const mockVideo = createMockVideo();
+  mockDOM.container.appendChild(mockVideo);
+  const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+  const shadowController = controller.div.shadowRoot.querySelector('#controller');
+  const draggable = controller.div.shadowRoot.querySelector('.draggable');
+
+  let captured = false;
+  draggable.setPointerCapture = () => { captured = true; };
+  draggable.releasePointerCapture = () => {};
+
+  // Simulate pointerdown with pointerId
+  const pointerEvent = new Event('pointerdown', { bubbles: true });
+  pointerEvent.clientX = 100;
+  pointerEvent.clientY = 100;
+  pointerEvent.pointerId = 1;
+  Object.defineProperty(pointerEvent, 'target', { value: draggable, writable: true });
+
+  window.VSC.DragHandler.handleDrag(mockVideo, pointerEvent);
+
+  assert.true(captured, 'setPointerCapture should have been called');
+  assert.true(
+    shadowController.classList.contains('dragging'),
+    'Should add dragging class'
+  );
+});
+
+runner.test('DragHandler.handleDrag falls back to mouse events without pointerId', async () => {
+  const config = window.VSC.videoSpeedConfig;
+  await config.load();
+  const eventManager = new window.VSC.EventManager(config, null);
+  const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+  const mockVideo = createMockVideo();
+  mockDOM.container.appendChild(mockVideo);
+  const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+  const shadowController = controller.div.shadowRoot.querySelector('#controller');
+  const draggable = controller.div.shadowRoot.querySelector('.draggable');
+
+  // Simulate mousedown without pointerId
+  const mouseEvent = new Event('mousedown', { bubbles: true });
+  mouseEvent.clientX = 50;
+  mouseEvent.clientY = 50;
+  Object.defineProperty(mouseEvent, 'target', { value: draggable, writable: true });
+
+  window.VSC.DragHandler.handleDrag(mockVideo, mouseEvent);
+
+  assert.true(
+    shadowController.classList.contains('dragging'),
+    'Should add dragging class on mouse fallback'
+  );
+});
+
+// --- Double-click-to-reset tests ---
+
+runner.test('ControlsManager sets up dblclick handler on draggable', async () => {
+  const config = window.VSC.videoSpeedConfig;
+  await config.load();
+  const eventManager = new window.VSC.EventManager(config, null);
+  const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+  const mockVideo = createMockVideo();
+  mockDOM.container.appendChild(mockVideo);
+  const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+  // Change speed away from 1.0
+  mockVideo.playbackRate = 2.0;
+  if (mockVideo.vsc.speedIndicator) {
+    mockVideo.vsc.speedIndicator.textContent = '2.00';
+  }
+
+  // Track if reset was called
+  let resetCalled = false;
+  const origRunAction = actionHandler.runAction.bind(actionHandler);
+  actionHandler.runAction = (action, value, e) => {
+    if (action === 'reset') {
+      resetCalled = true;
+    }
+    return origRunAction(action, value, e);
+  };
+
+  // Dispatch dblclick on the draggable
+  const draggable = controller.div.shadowRoot.querySelector('.draggable');
+  const dblClickEvent = new Event('dblclick', { bubbles: true, cancelable: true });
+  Object.defineProperty(dblClickEvent, 'target', { value: draggable, writable: true });
+  draggable.dispatchEvent(dblClickEvent);
+
+  assert.true(resetCalled, 'Double-click on speed indicator should trigger reset action');
+});
+
+runner.test('Draggable element has touch-action: none in style', async () => {
+  const config = window.VSC.videoSpeedConfig;
+  await config.load();
+  const eventManager = new window.VSC.EventManager(config, null);
+  const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+  const mockVideo = createMockVideo();
+  mockDOM.container.appendChild(mockVideo);
+  const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+  // Check that the shadow DOM style contains touch-action: none for .draggable
+  const style = controller.div.shadowRoot.querySelector('style');
+  assert.true(
+    style.textContent.includes('touch-action: none'),
+    'Shadow DOM styles should include touch-action: none for draggable'
+  );
+});
+
+export { runner };


### PR DESCRIPTION
Refactor DragHandler from mouse-only events to pointer events with
setPointerCapture, enabling drag on both desktop and mobile/tablet.
Add double-click/double-tap on the speed indicator to reset playback
speed, giving mobile users access to reset without a keyboard shortcut.