### PR TITLE
feat: snap to 1.0x when crossing boundary during speed adjust

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -385,6 +385,12 @@ class ActionHandler {
       // For relative changes, add to current speed
       const currentSpeed = video.playbackRate < 0.1 ? 0.0 : video.playbackRate;
       targetSpeed = currentSpeed + value;
+
+      // Snap to 1.0x when crossing the 1.0 boundary
+      if ((currentSpeed > 1.0 && targetSpeed < 1.0) || (currentSpeed < 1.0 && targetSpeed > 1.0)) {
+        targetSpeed = 1.0;
+      }
+
       window.VSC.logger.debug(`Relative speed calculation: currentSpeed=${currentSpeed} + ${value} = ${targetSpeed}`);
     } else {
       // For absolute changes, use value directly


### PR DESCRIPTION
## Summary
- When incrementing/decrementing speed crosses the 1.0x boundary, snap to 1.0x instead of overshooting (e.g. 1.05 → 1.0 instead of 1.05 → 0.95)
- Always on, no toggle — one extra keypress to get past 1.0 if needed
- Inspired by #1412, implemented without the settings/UI overhead

## Test plan
- [ ] Set speed to 1.3x, decrement by 0.1 repeatedly — should snap to 1.0 before going to 0.9
- [ ] Set speed to 0.8x, increment by 0.1 repeatedly — should snap to 1.0 before going to 1.1
- [ ] Verify absolute speed sets (reset, preferred speed) are unaffected