### PR TITLE
Add toggle behavior to jump-to-marker action

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -276,12 +276,25 @@ class ActionHandler {
   }
 
   /**
-   * Jump to time marker
+   * Jump to time marker, or jump back to previous position if already at marker
    * @param {HTMLMediaElement} video - Video element
    */
   jumpToMark(video) {
-    window.VSC.logger.debug('Recalling marker');
-    if (video.vsc.mark && typeof video.vsc.mark === 'number') {
+    if (video.vsc.mark == null || typeof video.vsc.mark !== 'number') {
+      return;
+    }
+
+    const currentTime = video.currentTime;
+
+    if (video.vsc.positionBeforeJump !== null && Math.abs(currentTime - video.vsc.mark) < 0.05) {
+      // At the marker — toggle back to where we came from
+      window.VSC.logger.debug('Jumping back to pre-marker position');
+      video.currentTime = video.vsc.positionBeforeJump;
+      video.vsc.positionBeforeJump = null;
+    } else {
+      // Jump to marker, remembering current position
+      window.VSC.logger.debug('Jumping to marker');
+      video.vsc.positionBeforeJump = currentTime;
       video.currentTime = video.vsc.mark;
     }
   }

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -24,6 +24,7 @@ class VideoController {
 
     // Transient reset memory (not persisted, instance-specific)
     this.speedBeforeReset = null;
+    this.positionBeforeJump = null;
 
     // Attach controller to video element first (needed for adjustSpeed)
     target.vsc = this;


### PR DESCRIPTION
## Summary

- Pressing Jump (J) while at the marker now toggles back to the pre-jump position, mirroring how Reset Speed (R) already toggles between current and target speed
- Adds `positionBeforeJump` to `VideoController` following the same pattern as `speedBeforeReset`
- Uses a 50ms threshold for position comparison to account for frame-alignment drift

Fixes #1334

## Test plan

- [ ] Set a marker (M) at some point in a video, seek elsewhere, press Jump (J) — should jump to marker
- [ ] Press Jump (J) again while at the marker — should jump back to the pre-jump position
- [ ] Manually seek away from marker after jumping to it, then press Jump (J) — should jump to marker (not toggle back), since position changed
- [ ] Verify marker set/jump works the same for both forward and backward markers
- [ ] Verify behavior works in both paused and playing states