### PR TITLE
Unify controller visibility system and fix race conditions

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -42,8 +42,6 @@ class ActionHandler {
         return;
       }
 
-      this.eventManager.showController(controller);
-
       if (!v.classList.contains('vsc-cancelled')) {
         this.executeAction(action, value, v, e);
       }
@@ -96,33 +94,30 @@ class ActionHandler {
           return;
         }
 
-        controller.classList.add('vsc-manual');
+        // Clear any pending flash timer before toggling
+        if (controller.flashTimer !== undefined) {
+          clearTimeout(controller.flashTimer);
+          controller.flashTimer = undefined;
+        }
+
         controller.classList.toggle('vsc-hidden');
 
-        // Clear any pending timers that might interfere with manual toggle
-        // This prevents delays when manually hiding/showing the controller
-        if (controller.blinkTimeOut !== undefined) {
-          clearTimeout(controller.blinkTimeOut);
-          controller.blinkTimeOut = undefined;
-        }
-
-        // Also clear EventManager timer if it exists
-        if (this.eventManager && this.eventManager.timer) {
-          clearTimeout(this.eventManager.timer);
-          this.eventManager.timer = null;
-        }
-
-        // Remove vsc-show class immediately when manually hiding
         if (controller.classList.contains('vsc-hidden')) {
+          // User is hiding — mark as manual, remove flash override
+          controller.classList.add('vsc-manual');
           controller.classList.remove('vsc-show');
-          window.VSC.logger.debug('Removed vsc-show class for immediate manual hide');
+        } else if (!this.config.settings.startHidden) {
+          // User is showing and startHidden=false — clear manual flag
+          // Controller returns to fully automatic behavior
+          controller.classList.remove('vsc-manual');
         }
+        // When startHidden=true and showing: vsc-manual stays (permits future flashing)
         break;
       }
 
       case 'blink':
         window.VSC.logger.debug('Showing controller momentarily');
-        this.blinkController(video.vsc.div, value);
+        this.flashController(video.vsc.div, value);
         break;
 
       case 'drag':
@@ -209,11 +204,6 @@ class ActionHandler {
    * @param {number} target - Target speed (usually 1.0)
    */
   resetSpeed(video, target) {
-    // Show controller for visual feedback (will be shown by adjustSpeed but we can show it early)
-    if (video.vsc?.div && this.eventManager) {
-      this.eventManager.showController(video.vsc.div);
-    }
-
     if (!video.vsc) {
       window.VSC.logger.warn('resetSpeed called on video without controller');
       return;
@@ -300,38 +290,45 @@ class ActionHandler {
   }
 
   /**
-   * Show controller briefly
+   * Flash controller briefly for visual feedback.
+   * Single entry point for all temporary visibility — replaces both
+   * blinkController and EventManager.showController.
    * @param {HTMLElement} controller - Controller element
-   * @param {number} duration - Duration in ms (default 1000)
+   * @param {number} duration - Duration in ms (default 2000)
    */
-  blinkController(controller, duration) {
-    // Don't hide audio controllers after blinking - audio elements are often invisible by design
-    // but should maintain visible controllers for user interaction
+  flashController(controller, duration) {
+    // When startHidden is enabled, only flash if user has manually shown
+    // this controller (vsc-manual flag). This prevents unwanted appearances.
+    if (this.config.settings.startHidden && !controller.classList.contains('vsc-manual')) {
+      window.VSC.logger.debug('flashController skipped: startHidden and no vsc-manual');
+      return;
+    }
+
     const isAudioController = this.isAudioController(controller);
 
-    // Always clear any existing timeout first
-    if (controller.blinkTimeOut !== undefined) {
-      clearTimeout(controller.blinkTimeOut);
-      controller.blinkTimeOut = undefined;
+    // Always clear any existing timer first (timer invariant: one per controller)
+    if (controller.flashTimer !== undefined) {
+      clearTimeout(controller.flashTimer);
+      controller.flashTimer = undefined;
     }
 
     // Add vsc-show class to temporarily show controller
-    // This overrides vsc-hidden via CSS specificity
+    // This overrides vsc-hidden and vsc-autohide via CSS source order
     controller.classList.add('vsc-show');
     window.VSC.logger.debug('Showing controller temporarily with vsc-show class');
 
     // For audio controllers, don't set timeout to hide again
     if (!isAudioController) {
-      controller.blinkTimeOut = setTimeout(
+      controller.flashTimer = setTimeout(
         () => {
           controller.classList.remove('vsc-show');
-          controller.blinkTimeOut = undefined;
-          window.VSC.logger.debug('Removing vsc-show class after timeout');
+          controller.flashTimer = undefined;
+          window.VSC.logger.debug('Removing vsc-show class after flash timeout');
         },
-        duration ? duration : 2500
+        duration || 2000
       );
     } else {
-      window.VSC.logger.debug('Audio controller blink - keeping vsc-show class');
+      window.VSC.logger.debug('Audio controller flash - keeping vsc-show class');
     }
   }
 
@@ -386,11 +383,6 @@ class ActionHandler {
    */
   _adjustSpeedInternal(video, value, options) {
     const { relative = false, source = 'internal' } = options;
-
-    // Show controller for visual feedback when speed is changed
-    if (video.vsc?.div && this.eventManager) {
-      this.eventManager.showController(video.vsc.div);
-    }
 
     // Calculate target speed
     let targetSpeed;
@@ -491,9 +483,9 @@ class ActionHandler {
       }
     }
 
-    // 7. Show controller briefly for visual feedback
+    // 7. Flash controller briefly for visual feedback
     if (video.vsc?.div) {
-      this.blinkController(video.vsc.div);
+      this.flashController(video.vsc.div);
     }
   }
 

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -42,13 +42,75 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
   }
 
   /**
-   * Set up YouTube-specific CSS classes and positioning
+   * Set up YouTube-specific CSS and autohide class forwarding.
+   * Watches for YouTube's .ytp-autohide class on the player element
+   * and forwards it as vsc-autohide on all vsc-controller elements
+   * within that player, so the shadow DOM CSS can handle visibility.
    * @private
    */
   setupYouTubeCSS() {
-    // YouTube has complex CSS that can hide our controller
-    // The inject.css already handles this, but we could add dynamic adjustments here
+    this.setupAutohideForwarding();
     window.VSC.logger.debug('YouTube CSS setup completed');
+  }
+
+  /**
+   * Observe .html5-video-player for ytp-autohide class changes
+   * and forward as vsc-autohide to controllers within the player.
+   * @private
+   */
+  setupAutohideForwarding() {
+    // Find the YouTube player element
+    const player = document.querySelector('.html5-video-player');
+    if (!player) {
+      window.VSC.logger.debug('YouTube player element not found, will retry on mutation');
+      // Retry when player appears in DOM
+      const bodyObserver = new MutationObserver(() => {
+        const p = document.querySelector('.html5-video-player');
+        if (p) {
+          bodyObserver.disconnect();
+          this.observePlayerAutohide(p);
+        }
+      });
+      bodyObserver.observe(document.body, { childList: true, subtree: true });
+      this.autohideBodyObserver = bodyObserver;
+      return;
+    }
+
+    this.observePlayerAutohide(player);
+  }
+
+  /**
+   * Set up MutationObserver on the player element for autohide forwarding.
+   * @param {HTMLElement} player - The .html5-video-player element
+   * @private
+   */
+  observePlayerAutohide(player) {
+    const syncAutohide = () => {
+      const hasAutohide = player.classList.contains('ytp-autohide');
+      const controllers = player.querySelectorAll('vsc-controller');
+      controllers.forEach((controller) => {
+        if (hasAutohide) {
+          controller.classList.add('vsc-autohide');
+        } else {
+          controller.classList.remove('vsc-autohide');
+        }
+      });
+    };
+
+    // Sync initial state
+    syncAutohide();
+
+    this.autohideObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'class') {
+          syncAutohide();
+          break;
+        }
+      }
+    });
+
+    this.autohideObserver.observe(player, { attributes: true, attributeFilter: ['class'] });
+    window.VSC.logger.debug('YouTube autohide forwarding observer set up');
   }
 
   /**

--- a/src/styles/inject.css
+++ b/src/styles/inject.css
@@ -18,17 +18,6 @@ vsc-controller {
   top: 10px;
 }
 
-.ytp-autohide vsc-controller {
-  visibility: hidden;
-  transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  opacity: 0;
-}
-
-.ytp-autohide .vsc-show {
-  visibility: visible;
-  opacity: 1;
-}
-
 /* YouTube embedded player */
 /* e.g. https://www.igvita.com/2012/09/12/web-fonts-performance-making-pretty-fast/ */
 .html5-video-player:not(.ytp-hide-info-bar) vsc-controller {

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -36,14 +36,21 @@ class ShadowDOMManager {
         visibility: hidden !important;
         opacity: 0 !important;
       }
-      
+
+      /* YouTube autohide — fade with player controls */
+      :host(.vsc-autohide) #controller {
+        visibility: hidden !important;
+        opacity: 0 !important;
+        transition: opacity 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+
       /* Override hiding for manual controllers (unless explicitly hidden) */
       :host(.vsc-manual:not(.vsc-hidden)) #controller {
         display: block !important;
         visibility: visible !important;
         opacity: ${opacity} !important;
       }
-      
+
       /* Show shadow DOM content when host has vsc-show class (highest priority) */
       :host(.vsc-show) #controller {
         display: block !important;

--- a/src/utils/debug-helper.js
+++ b/src/utils/debug-helper.js
@@ -153,12 +153,16 @@ class DebugHelper {
       const isHidden = controller.classList.contains('vsc-hidden');
       const isManual = controller.classList.contains('vsc-manual');
       const hasNoSource = controller.classList.contains('vsc-nosource');
+      const isAutohide = controller.classList.contains('vsc-autohide');
+      const isShow = controller.classList.contains('vsc-show');
 
       console.log('VSC State:', {
         hidden: isHidden,
         manual: isManual,
         noSource: hasNoSource,
-        effectivelyVisible: !isHidden && style.display !== 'none',
+        autohide: isAutohide,
+        show: isShow,
+        effectivelyVisible: !isHidden && !isAutohide && style.display !== 'none',
       });
 
       // Find associated video
@@ -287,14 +291,9 @@ class DebugHelper {
 
     const controllers = document.querySelectorAll('vsc-controller');
     controllers.forEach((controller, index) => {
-      // Remove all hiding classes
-      controller.classList.remove('vsc-hidden', 'vsc-nosource');
+      // Remove all hiding classes and rely on vsc-show for visibility
+      controller.classList.remove('vsc-hidden', 'vsc-nosource', 'vsc-autohide');
       controller.classList.add('vsc-manual', 'vsc-show');
-
-      // Force visibility styles
-      controller.style.display = 'block !important';
-      controller.style.visibility = 'visible !important';
-      controller.style.opacity = '1 !important';
 
       console.log(`Controller #${index + 1} forced visible`);
     });
@@ -315,14 +314,9 @@ class DebugHelper {
       if (audio.vsc && audio.vsc.div) {
         const controller = audio.vsc.div;
 
-        // Remove all hiding classes
-        controller.classList.remove('vsc-hidden', 'vsc-nosource');
+        // Remove all hiding classes and rely on vsc-show for visibility
+        controller.classList.remove('vsc-hidden', 'vsc-nosource', 'vsc-autohide');
         controller.classList.add('vsc-manual', 'vsc-show');
-
-        // Force visibility styles
-        controller.style.display = 'block !important';
-        controller.style.visibility = 'visible !important';
-        controller.style.opacity = '1 !important';
 
         console.log(`Audio controller #${index + 1} forced visible`);
         controllersShown++;
@@ -377,6 +371,8 @@ class DebugHelper {
               classes: target.className,
               hidden: target.classList.contains('vsc-hidden'),
               manual: target.classList.contains('vsc-manual'),
+              autohide: target.classList.contains('vsc-autohide'),
+              show: target.classList.contains('vsc-show'),
             });
           }
         }

--- a/src/utils/event-manager.js
+++ b/src/utils/event-manager.js
@@ -10,7 +10,6 @@ class EventManager {
     this.actionHandler = actionHandler;
     this.listeners = new Map();
     this.coolDown = false;
-    this.timer = null;
 
     // Event deduplication to prevent duplicate key processing
     this.lastKeyEventSignature = null;
@@ -318,37 +317,6 @@ class EventManager {
   }
 
   /**
-   * Show controller temporarily during speed changes or other automatic actions
-   * @param {Element} controller - Controller element
-   */
-  showController(controller) {
-    // When startHidden is enabled, only show temporary feedback if the user has
-    // previously interacted with this controller manually (vsc-manual class)
-    // This prevents unwanted controller appearances on pages where user wants them hidden
-    if (this.config.settings.startHidden && !controller.classList.contains('vsc-manual')) {
-      window.VSC.logger.info(
-        `Controller respecting startHidden setting - no temporary display (startHidden: ${this.config.settings.startHidden}, manual: ${controller.classList.contains('vsc-manual')})`
-      );
-      return;
-    }
-
-    window.VSC.logger.info(
-      `Showing controller temporarily (startHidden: ${this.config.settings.startHidden}, manual: ${controller.classList.contains('vsc-manual')})`
-    );
-    controller.classList.add('vsc-show');
-
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
-
-    this.timer = setTimeout(() => {
-      controller.classList.remove('vsc-show');
-      this.timer = null;
-      window.VSC.logger.debug('Hiding controller');
-    }, 2000);
-  }
-
-  /**
    * Clean up all event listeners
    */
   cleanup() {
@@ -367,11 +335,6 @@ class EventManager {
     if (this.coolDown) {
       clearTimeout(this.coolDown);
       this.coolDown = false;
-    }
-
-    if (this.timer) {
-      clearTimeout(this.timer);
-      this.timer = null;
     }
 
     if (this.fightTimer) {

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -270,12 +270,12 @@ runner.test('ActionHandler should toggle display visibility', async () => {
   assert.true(controller.classList.contains('vsc-hidden'));
   assert.true(controller.classList.contains('vsc-manual'));
 
-  // Second toggle - should show
+  // Second toggle - should show, vsc-manual cleared (startHidden=false)
   actionHandler.runAction('display', null, null);
   assert.false(controller.classList.contains('vsc-hidden'));
-  assert.true(controller.classList.contains('vsc-manual'));
+  assert.false(controller.classList.contains('vsc-manual'));
 
-  // Third toggle - should hide again
+  // Third toggle - should hide again, vsc-manual re-added
   actionHandler.runAction('display', null, null);
   assert.true(controller.classList.contains('vsc-hidden'));
   assert.true(controller.classList.contains('vsc-manual'));


### PR DESCRIPTION
## Summary

This PR audits and refactors the controller visibility system to eliminate race conditions, remove redundant code paths, and establish a single source of truth for visibility control. The system previously had two independent "temporarily show" mechanisms (`showController` and `blinkController`) operating on the same CSS class with different timers, causing controllers to disappear prematurely. This change consolidates visibility logic into a unified `flashController` function and moves all visibility CSS rules into the shadow DOM.

## Key Changes

- **Unified flash function**: Renamed `blinkController` to `flashController` and removed the separate `showController` method. All temporary visibility now goes through a single entry point with one timer per controller (`controller.flashTimer`).

- **Removed redundant calls**: Eliminated three redundant `showController` calls from `runAction()`, `resetSpeed()`, and `_adjustSpeedInternal()` that were duplicating the flash triggered by `setSpeed()`.

- **Fixed vsc-manual lifecycle**: The `vsc-manual` class is now properly cleared when a user re-shows a controller (unless `startHidden=true`, where it must persist to permit future flashing). Previously it was write-only and never cleared.

- **Moved YouTube autohide to shadow DOM**: Removed light-DOM CSS rules for YouTube autohide and the vestigial `.vsc-show` rule. Added a new `:host(.vsc-autohide)` rule in shadow DOM and implemented class forwarding via `YouTubeHandler` to observe YouTube's `.ytp-autohide` class and sync it to controllers.

- **Simplified display action**: Consolidated timer cleanup to reference the single `flashTimer` property and added conditional logic to clear `vsc-manual` only when appropriate.

- **Updated debug helper**: Removed inline style overrides and added support for the new `vsc-autohide` class in visibility diagnostics.

## Implementation Details

- **Timer invariant**: The unified `flashController` always clears any existing timer before setting a new one, ensuring at most one active timer per controller (the old system had a shared global timer plus per-controller timers, causing interference).

- **CSS specificity**: All shadow DOM visibility rules use `:host()` selectors with identical specificity. The override chain is enforced by source order: `vsc-show` (last) overrides `vsc-autohide` and `vsc-manual`, which override `vsc-hidden`.

- **startHidden gate**: The `flashController` method includes the `startHidden && !vsc-manual` check that was previously only in `showController`, preventing unwanted visibility when the user wants controllers hidden by default.

- **YouTube integration**: A new `setupAutohideForwarding()` method in `YouTubeHandler` observes the `.html5-video-player` element for class changes and syncs the `ytp-autohide` class to `vsc-autohide` on all controllers within that player.

## Testing

Updated `action-handler.test.js` to verify that `vsc-manual` is cleared after a user re-shows a controller (when `startHidden=false`). The state machine transitions are now deterministic with no timer races.