### PR TITLE
Wheel scroll: two-layer filtering to prevent accidental speed changes

### DIFF
--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -105,9 +105,30 @@ class ControlsManager {
   setupWheelHandler(shadow, video) {
     const controller = shadow.querySelector('#controller');
 
+    // Hover dwell gate: only allow wheel events after the cursor has rested on the
+    // controller for HOVER_DWELL_MS. This prevents accidental speed changes when
+    // scrolling through feed-based sites (Twitter, Reddit) where the cursor briefly
+    // passes over the controller. See #1352.
+    const HOVER_DWELL_MS = 300;
+    let hoverStart = 0;
+
+    controller.addEventListener('mouseenter', (e) => {
+      hoverStart = e.timeStamp;
+    });
+
+    controller.addEventListener('mouseleave', () => {
+      hoverStart = 0;
+    });
+
     controller.addEventListener(
       'wheel',
       (event) => {
+        // Reject wheel events before hover dwell threshold is met
+        if (event.timeStamp - hoverStart < HOVER_DWELL_MS) {
+          window.VSC.logger.debug('Wheel ignored: hover dwell threshold not met');
+          return;
+        }
+
         // Detect and filter touchpad events to prevent interference during page scrolling
         if (event.deltaMode === event.DOM_DELTA_PIXEL) {
           // Chrome/Safari/Edge: Use magnitude to distinguish mouse wheel (>50px) from touchpad (<50px)


### PR DESCRIPTION
PROBLEM

The speed controller overlay sits in the top-left corner of every
video. On feed-based sites (Twitter/X, Reddit, YouTube Shorts) users
scroll vertically through content, and their cursor frequently passes
over — or rests on — the controller. Without filtering, these scroll
events get intercepted as speed adjustments: the user scrolls the
page, the video silently changes to 0.1x, and they don't notice
until playback sounds wrong.

The core challenge is intent disambiguation: a wheel event over the
controller could mean "adjust speed" or "scroll the page." The event
object carries no intent flag, so we infer it from context.

DESIGN

Two independent guards run in sequence before a wheel event is
accepted. Each targets a different class of false positive:

1. Hover dwell gate (300ms)

   Tracks mouseenter/mouseleave timestamps on the controller element.
   A wheel event is rejected unless the cursor has been hovering for
   at least 300ms. This filters the dominant accidental-trigger
   scenario: user scrolls a feed, cursor crosses the controller
   transiently, next scroll tick fires a wheel event on the overlay.

   300ms was chosen because it is below the perceptual threshold for
   intentional use (hover → decide to scroll → scroll is naturally
   >300ms) while catching scroll-by cursors that enter and immediately
   generate wheel events.

   Uses event.timeStamp (DOMHighResTimeStamp, performance.now-based)
   so both mouseenter and wheel are compared on the same monotonic
   clock. hoverStart resets to 0 on mouseleave, which makes the
   (event.timeStamp - 0) delta always large enough to pass — this is
   safe because a wheel event without a preceding mouseenter means
   the cursor was already resting on the controller at page load.

2. Touchpad magnitude threshold (50px deltaY)

   In DOM_DELTA_PIXEL mode (Chrome/Safari/Edge for all devices),
   mouse wheels produce ~100px deltas while touchpads produce ~1-15px.
   Events below 50px are rejected as touchpad scrolls.

   Firefox is unaffected: mouse wheels report DOM_DELTA_LINE (pass
   through), touchpads report DOM_DELTA_PIXEL with small deltas
   (caught by the threshold).

WHAT THIS DOES NOT DO

- No user-facing setting or toggle. The filtering is automatic and
  invisible. A settings toggle was considered and rejected: it shifts
  burden to the user, has a discovery problem, and forces an
  all-or-nothing choice between accidental triggers and no wheel
  support at all.

- No preventDefault on rejected events. Rejected wheel events
  propagate normally, so the page scrolls as the user intended.

- No impact on keyboard shortcuts or button clicks. Those code paths
  call actionHandler.adjustSpeed() directly, bypassing the wheel
  handler entirely.