### PR TITLE
Add settings export/import to options page

### DIFF
--- a/src/ui/options/options.css
+++ b/src/ui/options/options.css
@@ -463,6 +463,11 @@ button:focus-visible {
   gap: 12px;
 }
 
+.secondary-buttons {
+  display: flex;
+  gap: 12px;
+}
+
 /* Status message */
 #status {
   display: block;
@@ -682,6 +687,15 @@ button:focus-visible {
   }
 
   .primary-buttons button {
+    flex: 1;
+  }
+
+  .secondary-buttons {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .secondary-buttons button {
     flex: 1;
   }
 }

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -141,7 +141,12 @@
       <button id="save">Save</button>
       <button id="experimental">Show advanced features</button>
     </div>
-    <button id="restore">Restore defaults</button>
+    <div class="secondary-buttons">
+      <button id="export" class="secondary">Export</button>
+      <button id="import" class="secondary">Import</button>
+      <input type="file" id="importFile" accept=".json" hidden />
+      <button id="restore">Restore defaults</button>
+    </div>
   </div>
 
   <div id="status"></div>

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -666,6 +666,111 @@ async function restore_defaults() {
   }
 }
 
+/**
+ * Export all settings as a JSON file download.
+ */
+async function export_settings() {
+  var status = document.getElementById("status");
+  try {
+    // Ensure config is loaded
+    if (!window.VSC.videoSpeedConfig) {
+      window.VSC.videoSpeedConfig = new window.VSC.VideoSpeedConfig();
+    }
+    await window.VSC.videoSpeedConfig.load();
+    const settings = { ...window.VSC.videoSpeedConfig.settings };
+
+    const blob = new Blob([JSON.stringify(settings, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "videospeed-settings.json";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    status.textContent = "Settings exported";
+    status.classList.remove("error");
+    status.classList.add("show", "success");
+    setTimeout(function () {
+      status.textContent = "";
+      status.classList.remove("show", "success");
+    }, 2000);
+  } catch (error) {
+    console.error("Failed to export settings:", error);
+    status.textContent = "Error exporting settings: " + error.message;
+    status.classList.add("show", "error");
+    setTimeout(function () {
+      status.textContent = "";
+      status.classList.remove("show", "error");
+    }, 3000);
+  }
+}
+
+/**
+ * Import settings from a JSON file. Validates structure before applying.
+ */
+function import_settings() {
+  document.getElementById("importFile").click();
+}
+
+async function handleImportFile(event) {
+  var status = document.getElementById("status");
+  var file = event.target.files[0];
+  if (!file) return;
+
+  // Reset the input so the same file can be re-selected
+  event.target.value = "";
+
+  try {
+    var text = await file.text();
+    var imported;
+    try {
+      imported = JSON.parse(text);
+    } catch (e) {
+      throw new Error("File is not valid JSON");
+    }
+
+    if (!imported || typeof imported !== "object" || !Array.isArray(imported.keyBindings)) {
+      throw new Error("File does not look like a Video Speed Controller settings file");
+    }
+
+    // Ensure config is initialized
+    if (!window.VSC.videoSpeedConfig) {
+      window.VSC.videoSpeedConfig = new window.VSC.VideoSpeedConfig();
+    }
+
+    // Clear existing storage and write the imported settings
+    await window.VSC.StorageManager.clear();
+    const ok = await window.VSC.videoSpeedConfig.save(imported);
+    if (!ok) throw new Error("Failed to write imported settings to storage");
+
+    // Remove custom shortcut rows before reloading UI
+    document
+      .querySelectorAll(".removeParent")
+      .forEach(function (button) { button.click(); });
+
+    // Reload settings into the UI
+    await restore_options();
+
+    status.textContent = "Settings imported successfully";
+    status.classList.remove("error");
+    status.classList.add("show", "success");
+    setTimeout(function () {
+      status.textContent = "";
+      status.classList.remove("show", "success");
+    }, 2000);
+  } catch (error) {
+    console.error("Failed to import settings:", error);
+    status.textContent = "Import failed: " + error.message;
+    status.classList.add("show", "error");
+    setTimeout(function () {
+      status.textContent = "";
+      status.classList.remove("show", "error");
+    }, 4000);
+  }
+}
+
 function toggle_experimental() {
   const button = document.getElementById("experimental");
   const advancedRows = document.querySelectorAll('.row.advanced-feature');
@@ -712,6 +817,18 @@ document.addEventListener("DOMContentLoaded", async function () {
     e.preventDefault();
     await restore_defaults();
   });
+
+  document.getElementById("export").addEventListener("click", (e) => {
+    e.preventDefault();
+    export_settings();
+  });
+
+  document.getElementById("import").addEventListener("click", (e) => {
+    e.preventDefault();
+    import_settings();
+  });
+
+  document.getElementById("importFile").addEventListener("change", handleImportFile);
 
   document.getElementById("experimental").addEventListener("click", toggle_experimental);
 


### PR DESCRIPTION
Problem
-------
Users with heavily customized setups (20+ keybindings, custom CSS,
blacklists) have no way to transfer settings between browser profiles,
machines, or browsers. chrome.storage.sync only covers a single Google
account in Chrome — it doesn't help across profiles, in Firefox, or for
explicit backups. This has been the top recurring feature request since
June 2022 (issues #947, #1329, #1347, #1390).

Solution
--------
Two buttons on the options page: "Export" and "Import".

Export reads the full settings object from VideoSpeedConfig, serializes
it as pretty-printed JSON, and triggers a file download
(videospeed-settings.json). Import opens a file picker, validates the
JSON has the expected shape (object with a keyBindings array), clears
storage, writes the imported blob via VideoSpeedConfig.save(), and
reloads the options UI in place.

Both operations use the existing VideoSpeedConfig + StorageManager
infrastructure. No new storage mechanisms, no new message types, no
background script changes.

Validation strategy: import checks for parseable JSON and the presence
of a keyBindings array — the one field every valid config has. We
deliberately skip schema version gating because VideoSpeedConfig.load()
and background.js already handle v1→v2 migration on read. This means
exported files from older versions will import cleanly.

Design decisions
----------------
- Full-blob export only. The settings object is ~2-4KB; selective
  field-level export/import adds UI complexity with no real benefit.

- No settings profiles or switching. Requested in #1329 comments, but
  profiles are a different feature with different UX (naming, switching,
  defaults). Export/import solves the portability problem without that
  scope creep.

- Clear-then-write on import. We call StorageManager.clear() before
  writing the imported settings to avoid stale keys from the previous
  config leaking through. This matches the restore_defaults() pattern
  already in the codebase.

- File picker reset after read. The hidden <input type="file"> value is
  cleared after each import so the same file can be re-imported without
  the browser suppressing the change event.

Files changed
-------------
- src/ui/options/options.html — Export/Import buttons + hidden file
  input in a new .secondary-buttons group
- src/ui/options/options.js  — export_settings(), import_settings(),
  handleImportFile() functions + event listener wiring
- src/ui/options/options.css  — .secondary-buttons layout + responsive
  rules for mobile

Closes #1329