### PR TITLE
Add handleSpeedChange hook to site handler API

### DIFF
--- a/docs/custom-player-handler.md
+++ b/docs/custom-player-handler.md
@@ -1,0 +1,268 @@
+# Custom Player Handler Guide
+
+Video Speed Controller uses site handlers to adapt to sites with custom video players. If a site uses non-standard DOM structure, a custom player API, or needs special behavior, you write a handler.
+
+## Quick start
+
+Create a file in `src/site-handlers/` that extends `BaseSiteHandler`:
+
+```js
+window.VSC = window.VSC || {};
+
+class ExampleHandler extends window.VSC.BaseSiteHandler {
+  static matches() {
+    return location.hostname === 'www.example.com';
+  }
+}
+
+window.VSC.ExampleHandler = ExampleHandler;
+```
+
+Register it in `src/site-handlers/index.js`:
+
+```js
+this.availableHandlers = [
+  // ...existing handlers...
+  window.VSC.ExampleHandler,
+];
+```
+
+Only override the methods you need. The base class provides sensible defaults for everything.
+
+## Architecture
+
+Site handlers run in the **page context** (MAIN world) via the `inject.js` bundle. They have full access to the page DOM and any player APIs exposed on `window`. They do **not** have access to `chrome.*` extension APIs.
+
+The `SiteHandlerManager` selects the first handler whose `static matches()` returns `true`, creates a singleton instance, and delegates all site-specific calls to it. If no handler matches, `BaseSiteHandler` is used directly.
+
+## API reference
+
+### Lifecycle
+
+#### `static matches()`
+
+Determines if this handler should be used for the current page.
+
+```js
+static matches() {
+  return location.hostname === 'www.example.com';
+}
+```
+
+Called once during handler detection. Return `true` to claim this site.
+
+#### `initialize(document)`
+
+Called once when the extension starts up on the page. Use for setting up observers, injecting site-specific CSS, or any one-time setup.
+
+```js
+initialize(document) {
+  super.initialize(document);
+  // your setup here
+}
+```
+
+Always call `super.initialize(document)` first.
+
+#### `cleanup()`
+
+Called when the extension is torn down (user disables it, navigates away on an SPA, etc.). Clean up any observers, timers, or DOM modifications you created in `initialize()`.
+
+```js
+cleanup() {
+  super.cleanup();
+  if (this.myObserver) {
+    this.myObserver.disconnect();
+    this.myObserver = null;
+  }
+}
+```
+
+### Video discovery
+
+These methods help the extension find and filter video elements on the page.
+
+#### `shouldIgnoreVideo(video)`
+
+Return `true` to skip a video element. Use this to filter out thumbnails, ads, or preview videos that shouldn't get a speed controller.
+
+```js
+shouldIgnoreVideo(video) {
+  return video.classList.contains('preview-thumbnail');
+}
+```
+
+#### `getVideoContainerSelectors()`
+
+Return CSS selectors that help the media scanner find video containers. These are used as hints, not strict requirements.
+
+```js
+getVideoContainerSelectors() {
+  return ['.custom-player', '#main-video-wrapper'];
+}
+```
+
+#### `detectSpecialVideos(document)`
+
+Return an array of video elements that can't be found through normal DOM scanning (e.g., inside shadow DOM or cross-origin-accessible iframes).
+
+```js
+detectSpecialVideos(document) {
+  const player = document.querySelector('custom-player');
+  if (player?.shadowRoot) {
+    return Array.from(player.shadowRoot.querySelectorAll('video'));
+  }
+  return [];
+}
+```
+
+### UI
+
+#### `getControllerPosition(parent, video)`
+
+Controls where the speed controller overlay is inserted in the DOM. Return an object with:
+
+- `insertionPoint` - the element to insert into
+- `insertionMethod` - `'firstChild'`, `'beforeParent'`, or `'afterParent'`
+- `targetParent` - the element used for positioning context
+
+```js
+getControllerPosition(parent, _video) {
+  // Insert into the player wrapper, above the video
+  return {
+    insertionPoint: parent.parentElement,
+    insertionMethod: 'firstChild',
+    targetParent: parent.parentElement,
+  };
+}
+```
+
+Override this when a site's player has overlays or stacking contexts that would cover the default position.
+
+### Playback
+
+These are the core operations. Each method **owns** the operation entirely -- the base class provides the default implementation, and your override replaces it completely.
+
+#### `handleSpeedChange(video, speed)`
+
+Called whenever the extension sets playback speed. This includes user-initiated speed changes, programmatic changes, and fight-back speed restoration.
+
+**Default behavior:**
+```js
+handleSpeedChange(video, speed) {
+  video.playbackRate = speed;
+}
+```
+
+Override when a site's player maintains its own speed state that must stay in sync with `video.playbackRate`. For example, if a site has a custom player API:
+
+```js
+handleSpeedChange(video, speed) {
+  video.playbackRate = speed;
+  const player = document.querySelector('#custom-player');
+  if (player?.setPlaybackRate) {
+    player.setPlaybackRate(speed);
+  }
+}
+```
+
+**Important:** Your override must always set `video.playbackRate`. The extension reads this property to determine the current speed. If you only call the site's API without setting `video.playbackRate`, the extension will think the speed didn't change.
+
+**When is this called?**
+
+| Scenario | Example |
+|---|---|
+| User changes speed | Keyboard shortcut, popup slider |
+| Extension restores speed | Page load with "remember speed" enabled |
+| Fight-back | Site tried to reset speed, extension restores it |
+| Cooldown restore | Site changed speed during cooldown window |
+
+All paths go through `handleSpeedChange`. There are no direct `video.playbackRate` assignments in the extension's core.
+
+#### `handleSeek(video, seekSeconds)`
+
+Called when the user seeks forward or backward. The `seekSeconds` value is negative for rewind.
+
+**Default behavior:**
+```js
+handleSeek(video, seekSeconds) {
+  const newTime = Math.max(0, Math.min(video.duration, video.currentTime + seekSeconds));
+  video.currentTime = newTime;
+  return true;
+}
+```
+
+Override when the site's player has its own seeking API (e.g., Netflix):
+
+```js
+handleSeek(video, seekSeconds) {
+  window.postMessage({
+    action: 'seek',
+    seekMs: seekSeconds * 1000,
+  }, 'https://www.example.com');
+  return true;
+}
+```
+
+## How speed changes flow through the system
+
+Understanding the speed change pipeline helps when debugging or writing a handler.
+
+```
+User action (keyboard, popup, etc.)
+  |
+  v
+ActionHandler.adjustSpeed(video, value, options)
+  |  - calculates target speed (absolute or relative)
+  |  - clamps to [0.07, 16]
+  |  - rounds to 2 decimal places
+  v
+ActionHandler.setSpeed(video, speed, source)
+  |  1. Starts cooldown (prevents ratechange re-entry)
+  |  2. Calls siteHandlerManager.handleSpeedChange(video, speed)
+  |     --> your handler runs here
+  |  3. Dispatches synthetic ratechange event
+  |  4. Updates UI indicator
+  |  5. Persists to storage (if rememberSpeed enabled)
+  v
+Done
+```
+
+When a site externally changes `video.playbackRate` (e.g., the site's own speed controls), the fight-back system detects it and calls `handleSpeedChange` to restore the user's speed. This means your handler's sync logic runs during fight-back too, keeping the site's player in sync.
+
+## Existing handlers
+
+| Handler | Site | Key overrides |
+|---|---|---|
+| `YouTubeHandler` | youtube.com | Controller positioning, autohide CSS forwarding, video filtering |
+| `NetflixHandler` | netflix.com | Controller positioning, custom seeking via postMessage |
+| `FacebookHandler` | facebook.com | Controller positioning, dynamic content observer |
+| `AmazonHandler` | amazon.com, primevideo.com | Controller positioning, size-based video filtering |
+| `AppleHandler` | tv.apple.com | Controller positioning, shadow DOM video detection |
+
+## Testing
+
+Tests go in `tests/unit/site-handlers/`. The test infrastructure provides:
+
+- `createMockVideo(options)` - creates a video element with configurable properties
+- `createMockDOM()` - sets up a minimal DOM environment
+- `installChromeMock()` / `cleanupChromeMock()` - mocks the Chrome extension API
+- `window.VSC.siteHandlerManager` - available after `installChromeMock()` + module loading
+
+To verify your handler is called during speed changes:
+
+```js
+const manager = window.VSC.siteHandlerManager;
+const handler = manager.getCurrentHandler();
+const spy = vi.spyOn(handler, 'handleSpeedChange');
+
+actionHandler.adjustSpeed(mockVideo, 2.0);
+
+expect(spy).toHaveBeenCalledWith(mockVideo, 2.0);
+```
+
+Run tests with:
+
+```
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,9 +1066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1083,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1106,9 +1100,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,9 +1117,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1146,9 +1134,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,9 +1151,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3063,9 +3045,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3087,9 +3066,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3111,9 +3087,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3135,9 +3108,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -469,8 +469,8 @@ class ActionHandler {
       this.eventManager.refreshCoolDown();
     }
 
-    // 2. Set the actual playback rate (native ratechange fires here, blocked by cooldown)
-    video.playbackRate = numericSpeed;
+    // 2. Set the actual playback rate via site handler (native ratechange fires here, blocked by cooldown)
+    window.VSC.siteHandlerManager.handleSpeedChange(video, numericSpeed);
 
     // 3. Dispatch synthetic event with source tracking
     video.dispatchEvent(

--- a/src/site-handlers/base-handler.js
+++ b/src/site-handlers/base-handler.js
@@ -32,6 +32,17 @@ class BaseSiteHandler {
   }
 
   /**
+   * Handle site-specific speed change.
+   * Called whenever the extension sets playback speed (user action, fight-back, etc.).
+   * Override to sync with a site's custom player API.
+   * @param {HTMLMediaElement} video - Video element
+   * @param {number} speed - Target speed
+   */
+  handleSpeedChange(video, speed) {
+    video.playbackRate = speed;
+  }
+
+  /**
    * Handle site-specific seeking functionality
    * @param {HTMLMediaElement} video - Video element
    * @param {number} seekSeconds - Seconds to seek

--- a/src/site-handlers/index.js
+++ b/src/site-handlers/index.js
@@ -65,6 +65,16 @@ class SiteHandlerManager {
   }
 
   /**
+   * Handle speed change for current site
+   * @param {HTMLMediaElement} video - Video element
+   * @param {number} speed - Target speed
+   */
+  handleSpeedChange(video, speed) {
+    const handler = this.getCurrentHandler();
+    handler.handleSpeedChange(video, speed);
+  }
+
+  /**
    * Handle seeking for current site
    * @param {HTMLMediaElement} video - Video element
    * @param {number} seekSeconds - Seconds to seek

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -176,15 +176,6 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
     return videos;
   }
 
-  /**
-   * Handle YouTube-specific player state changes
-   * @param {HTMLMediaElement} video - Video element
-   */
-  onPlayerStateChange(_video) {
-    // YouTube fires custom events we could listen to
-    // This could be used for better integration with YouTube's player
-    window.VSC.logger.debug('YouTube player state changed');
-  }
 }
 
 // Create singleton instance

--- a/src/utils/event-manager.js
+++ b/src/utils/event-manager.js
@@ -231,7 +231,7 @@ class EventManager {
           window.VSC.logger.info(
             `Restoring speed during cooldown from external ${video.playbackRate} to authoritative ${authoritativeSpeed}`
           );
-          video.playbackRate = authoritativeSpeed;
+          window.VSC.siteHandlerManager.handleSpeedChange(video, authoritativeSpeed);
         }
       }
 
@@ -307,7 +307,7 @@ class EventManager {
         window.VSC.logger.info(
           `Fight detection: attempt ${this.fightCount}/${EventManager.MAX_FIGHT_COUNT}, re-applying ${authoritativeSpeed} (cooldown ${cooldown}ms)`
         );
-        video.playbackRate = authoritativeSpeed;
+        window.VSC.siteHandlerManager.handleSpeedChange(video, authoritativeSpeed);
         this.refreshCoolDown(cooldown);
         event.stopImmediatePropagation();
         return;

--- a/tests/unit/site-handlers/handle-speed-change.test.js
+++ b/tests/unit/site-handlers/handle-speed-change.test.js
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for handleSpeedChange site handler hook
+ * Verifies that speed changes route through the handler system
+ */
+
+import { vi } from 'vitest';
+import {
+  installChromeMock,
+  cleanupChromeMock,
+  resetMockStorage,
+} from '../../helpers/chrome-mock.js';
+import { createMockVideo, createMockDOM } from '../../helpers/test-utils.js';
+
+let mockDOM;
+
+describe('handleSpeedChange', () => {
+  beforeEach(() => {
+    installChromeMock();
+    resetMockStorage();
+    mockDOM = createMockDOM();
+
+    if (window.VSC && window.VSC.stateManager) {
+      window.VSC.stateManager.controllers.clear();
+    }
+
+    if (window.VSC && window.VSC.siteHandlerManager) {
+      window.VSC.siteHandlerManager.initialize(document);
+    }
+  });
+
+  afterEach(() => {
+    cleanupChromeMock();
+    if (mockDOM) {
+      mockDOM.cleanup();
+    }
+  });
+
+  function createTestVideoWithController(config, actionHandler, videoOptions = {}) {
+    const mockVideo = createMockVideo(videoOptions);
+
+    if (!mockVideo.parentElement) {
+      const parentDiv = document.createElement('div');
+      document.body.appendChild(parentDiv);
+      parentDiv.appendChild(mockVideo);
+    }
+
+    const initialPlaybackRate = mockVideo.playbackRate;
+    new window.VSC.VideoController(mockVideo, mockVideo.parentElement, config, actionHandler);
+    mockVideo.playbackRate = initialPlaybackRate;
+
+    return mockVideo;
+  }
+
+  // --- BaseSiteHandler default ---
+
+  it('BaseSiteHandler.handleSpeedChange sets video.playbackRate', () => {
+    const handler = new window.VSC.BaseSiteHandler();
+    const video = createMockVideo({ playbackRate: 1.0 });
+
+    handler.handleSpeedChange(video, 3.0);
+
+    expect(video.playbackRate).toBe(3.0);
+  });
+
+  // --- SiteHandlerManager delegation ---
+
+  it('SiteHandlerManager delegates handleSpeedChange to current handler', () => {
+    const manager = window.VSC.siteHandlerManager;
+    const handler = manager.getCurrentHandler();
+    const spy = vi.spyOn(handler, 'handleSpeedChange');
+
+    const video = createMockVideo({ playbackRate: 1.0 });
+    manager.handleSpeedChange(video, 2.5);
+
+    expect(spy).toHaveBeenCalledWith(video, 2.5);
+    expect(video.playbackRate).toBe(2.5);
+    spy.mockRestore();
+  });
+
+  // --- ActionHandler.setSpeed routes through handler ---
+
+  it('ActionHandler.setSpeed uses handleSpeedChange instead of direct assignment', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+    const mockVideo = createTestVideoWithController(config, actionHandler, { playbackRate: 1.0 });
+
+    const manager = window.VSC.siteHandlerManager;
+    const spy = vi.spyOn(manager, 'handleSpeedChange');
+
+    actionHandler.setSpeed(mockVideo, 2.0, 'internal');
+
+    expect(spy).toHaveBeenCalledWith(mockVideo, 2.0);
+    expect(mockVideo.playbackRate).toBe(2.0);
+    spy.mockRestore();
+  });
+
+  it('adjustSpeed routes through handleSpeedChange', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+    const mockVideo = createTestVideoWithController(config, actionHandler, { playbackRate: 1.0 });
+
+    const manager = window.VSC.siteHandlerManager;
+    const spy = vi.spyOn(manager, 'handleSpeedChange');
+
+    actionHandler.adjustSpeed(mockVideo, 3.0);
+
+    expect(spy).toHaveBeenCalled();
+    expect(mockVideo.playbackRate).toBe(3.0);
+    spy.mockRestore();
+  });
+
+  // --- Fight-back routes through handler ---
+
+  it('fight-back restores speed through handleSpeedChange', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.lastSpeed = 2.0;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const eventManager = new window.VSC.EventManager(config, actionHandler);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockVideo.vsc = { speedIndicator: { textContent: '2.00' } };
+    Object.defineProperty(mockVideo, 'readyState', { value: 4, configurable: true });
+
+    const manager = window.VSC.siteHandlerManager;
+    const spy = vi.spyOn(manager, 'handleSpeedChange');
+
+    const mockEvent = {
+      composedPath: () => [mockVideo],
+      target: mockVideo,
+      detail: null,
+      stopImmediatePropagation: () => {},
+    };
+
+    eventManager.handleRateChange(mockEvent);
+
+    expect(spy).toHaveBeenCalledWith(mockVideo, 2.0);
+    expect(mockVideo.playbackRate).toBe(2.0);
+    spy.mockRestore();
+  });
+
+  it('cooldown restore routes through handleSpeedChange', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.lastSpeed = 2.0;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const eventManager = new window.VSC.EventManager(config, actionHandler);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockVideo.vsc = { speedIndicator: { textContent: '2.00' } };
+
+    const manager = window.VSC.siteHandlerManager;
+    const spy = vi.spyOn(manager, 'handleSpeedChange');
+
+    // Activate cooldown first
+    eventManager.refreshCoolDown();
+
+    const mockEvent = {
+      composedPath: () => [mockVideo],
+      target: mockVideo,
+      detail: null,
+      stopImmediatePropagation: () => {},
+    };
+
+    eventManager.handleRateChange(mockEvent);
+
+    expect(spy).toHaveBeenCalledWith(mockVideo, 2.0);
+    expect(mockVideo.playbackRate).toBe(2.0);
+    spy.mockRestore();
+  });
+
+  // --- Custom handler override ---
+
+  it('custom handler override is called during speed change', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+    const mockVideo = createTestVideoWithController(config, actionHandler, { playbackRate: 1.0 });
+
+    // Simulate a custom handler that records calls
+    const calls = [];
+    const handler = window.VSC.siteHandlerManager.getCurrentHandler();
+    handler.handleSpeedChange = (video, speed) => {
+      calls.push(speed);
+      video.playbackRate = speed;
+    };
+
+    actionHandler.adjustSpeed(mockVideo, 4.0);
+
+    expect(calls).toEqual([4.0]);
+    expect(mockVideo.playbackRate).toBe(4.0);
+  });
+});


### PR DESCRIPTION
Route all video.playbackRate assignments through the site handler
system, matching the existing handleSeek pattern. This gives site
handlers a clean way to sync speed changes with custom player APIs
(e.g. YouTube subtitle sync per #1185) without global monkey-patching.

- Add handleSpeedChange(video, speed) to BaseSiteHandler (default: sets
  video.playbackRate)
- Add delegation in SiteHandlerManager
- Wire ActionHandler.setSpeed() through the handler
- Wire EventManager fight-back and cooldown-restore through the handler
- Remove dead onPlayerStateChange from YouTubeHandler
- Add tests for all paths (base, delegation, setSpeed, fight-back,
  cooldown, custom override)
- Add docs/custom-player-handler.md developer guide