### PR TITLE
Remove close (×) button from controller overlay

### DIFF
--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -146,12 +146,6 @@ class ShadowDOMManager {
       button.rw {
         opacity: 0.65;
       }
-      
-      button.hideButton {
-        opacity: 0.65;
-        margin-left: 8px;
-        margin-right: 2px;
-      }
     `;
     shadow.appendChild(style);
 
@@ -179,7 +173,6 @@ class ShadowDOMManager {
       { action: 'slower', text: '−', class: '' },
       { action: 'faster', text: '+', class: '' },
       { action: 'advance', text: '»', class: 'rw' },
-      { action: 'display', text: '×', class: 'hideButton' },
     ];
 
     buttons.forEach((btnConfig) => {


### PR DESCRIPTION
The close button is an accidental-click magnet for mouse-only users
(#1431) and redundant now that hide/show is available via keyboard
shortcut (V) and the extension popup/options can disable the
controller globally or per-site.

The 'display' action and its keybinding are intentionally kept intact.