### PR TITLE
Skip speed overlay on gif-like video elements

### DIFF
--- a/src/site-handlers/index.js
+++ b/src/site-handlers/index.js
@@ -92,7 +92,20 @@ class SiteHandlerManager {
    */
   shouldIgnoreVideo(video) {
     const handler = this.getCurrentHandler();
-    return handler.shouldIgnoreVideo(video);
+    if (handler.shouldIgnoreVideo(video)) {
+      return true;
+    }
+
+    // Detect gif-like videos: muted looping videos with no native controls.
+    // Sites like Telegram, X, Imgur serve animated stickers/GIFs as <video
+    // autoplay loop muted> elements. Showing a speed overlay on these is
+    // visually noisy and not useful.
+    if (video.tagName === 'VIDEO' && video.loop && video.muted && !video.controls) {
+      window.VSC.logger.debug('Video ignored: gif-video pattern (loop + muted + no controls)');
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Skip speed controller overlay on gif-like `<video>` elements detected
  via `loop && muted && !controls` — the canonical pattern sites use to
  serve animated GIFs as MP4 video
- Fixes Telegram Web sticker overlays (#1407) and applies generically to
  X, Imgur, Giphy, background hero videos, etc.
- Single check in `SiteHandlerManager.shouldIgnoreVideo()`, always-on,
  no new settings

## Design

The heuristic `video.loop && video.muted && !video.controls` uniquely
identifies gif-as-video elements. Real video content is never simultaneously
looping and muted. The check runs after site-specific handlers, acting as a
universal fallback at the single filtering chokepoint. See commit message
for full rationale and false positive/negative analysis.