### PR TITLE
Restrict page→content bridge to set-speed only

### DIFF
--- a/src/content/injection-bridge.js
+++ b/src/content/injection-bridge.js
@@ -25,8 +25,20 @@ export async function injectScript(scriptPath) {
 }
 
 /**
+ * Speed limits for page→content bridge validation.
+ * Duplicated from constants.js because the content script (isolated world)
+ * cannot import page-context modules.
+ */
+const SPEED_MIN = 0.07;
+const SPEED_MAX = 16;
+
+/**
  * Set up message bridge between content script and page context.
- * Handles bi-directional communication for popup and settings updates.
+ *
+ * Page → Content accepts only `set-speed` (validated, clamped number).
+ * Content → Page provides storage-changed broadcasts and VSC_MESSAGE commands.
+ * All persistent settings writes go through trusted extension contexts.
+ *
  * @returns {{ sendCommand: (type: string, payload?: any) => void, cleanup: () => void }}
  */
 export function setupMessageBridge() {
@@ -40,20 +52,16 @@ export function setupMessageBridge() {
 
     if (source === 'vsc-page') {
       try {
-        if (action === 'storage-update') {
-          chrome.storage.sync.set(data);
-        } else if (action === 'runtime-message') {
-          if (data.type !== 'VSC_STATE_UPDATE') {
-            chrome.runtime.sendMessage(data);
+        if (action === 'set-speed') {
+          // Validate and clamp to supported range.
+          if (typeof data?.speed !== 'number' || !Number.isFinite(data.speed)) {
+            console.warn('[VSC] Bridge: rejected set-speed — invalid speed value');
+            return;
           }
-        } else if (action === 'get-storage') {
-          chrome.storage.sync.get(null, (items) => {
-            window.postMessage({
-              source: 'vsc-content',
-              action: 'storage-data',
-              data: items
-            }, '*');
-          });
+          const clamped = Math.min(Math.max(data.speed, SPEED_MIN), SPEED_MAX);
+          chrome.storage.sync.set({ lastSpeed: clamped });
+        } else {
+          console.warn(`[VSC] Bridge: unrecognized page action "${action}"`);
         }
       } catch (e) {
         if (e.message?.includes('Extension context invalidated')) {

--- a/src/core/storage-manager.js
+++ b/src/core/storage-manager.js
@@ -86,17 +86,28 @@ if (!window.VSC.StorageManager) {
           });
         });
       } else {
-        // Page context - send save request to content script via message bridge
-        window.VSC.logger.debug('Sending storage update to content script');
+        // Page context — only speed updates are bridged to the content script.
+        // All other settings writes go through extension contexts with direct
+        // chrome.storage access (options page, popup, background).
+        const keys = Object.keys(data);
+        if (keys.length === 1 && keys[0] === 'lastSpeed') {
+          const speed = data.lastSpeed;
+          if (typeof speed === 'number' && Number.isFinite(speed)) {
+            window.postMessage({
+              source: 'vsc-page',
+              action: 'set-speed',
+              data: { speed }
+            }, '*');
+          } else {
+            window.VSC.logger.warn('StorageManager.set: invalid lastSpeed value, ignoring');
+          }
+        } else {
+          window.VSC.logger.warn(
+            `StorageManager.set: only lastSpeed can be bridged from page context. Keys: ${keys.join(', ')}`
+          );
+        }
 
-        // Post message to content script
-        window.postMessage({
-          source: 'vsc-page',
-          action: 'storage-update',
-          data: data
-        }, '*');
-
-        // Update local settings cache
+        // Update local settings cache regardless (keeps in-memory state current)
         window.VSC_settings = { ...window.VSC_settings, ...data };
 
         return Promise.resolve();

--- a/tests/unit/content/injection-bridge.test.js
+++ b/tests/unit/content/injection-bridge.test.js
@@ -1,6 +1,6 @@
 /**
  * Unit tests for injection-bridge.js
- * Focused on the context invalidation fix and core message forwarding
+ * Validates bridge message handling, input validation, and context lifecycle
  */
 
 import {
@@ -39,34 +39,105 @@ describe('InjectionBridge', () => {
     window.dispatchEvent(event);
   }
 
-  // --- Core forwarding ---
+  // --- set-speed verb ---
 
-  it('storage-update forwards to chrome.storage.sync.set', () => {
+  it('set-speed writes clamped lastSpeed to chrome.storage', () => {
     let setData = null;
     chrome.storage.sync.set = (data) => {
       setData = data;
     };
 
     bridge = setupMessageBridge();
-    postPageMessage('storage-update', { lastSpeed: 2.5 });
+    postPageMessage('set-speed', { speed: 2.5 });
 
-    expect(setData).toBeDefined();
-    expect(setData.lastSpeed).toBe(2.5);
+    expect(setData).toEqual({ lastSpeed: 2.5 });
   });
 
-  it('runtime-message filters out VSC_STATE_UPDATE', () => {
-    let sendCalled = false;
-    chrome.runtime.sendMessage = () => {
-      sendCalled = true;
+  it('set-speed clamps speed to minimum (0.07)', () => {
+    let setData = null;
+    chrome.storage.sync.set = (data) => {
+      setData = data;
     };
 
     bridge = setupMessageBridge();
-    postPageMessage('runtime-message', { type: 'VSC_STATE_UPDATE' });
+    postPageMessage('set-speed', { speed: 0.01 });
 
-    expect(sendCalled).toBe(false);
+    expect(setData).toEqual({ lastSpeed: 0.07 });
   });
 
-  // --- Context invalidation (the actual fix) ---
+  it('set-speed clamps speed to maximum (16)', () => {
+    let setData = null;
+    chrome.storage.sync.set = (data) => {
+      setData = data;
+    };
+
+    bridge = setupMessageBridge();
+    postPageMessage('set-speed', { speed: 100 });
+
+    expect(setData).toEqual({ lastSpeed: 16 });
+  });
+
+  it('set-speed requires a numeric value', () => {
+    let setCalled = false;
+    chrome.storage.sync.set = () => {
+      setCalled = true;
+    };
+
+    bridge = setupMessageBridge();
+    postPageMessage('set-speed', { speed: 'fast' });
+
+    expect(setCalled).toBe(false);
+  });
+
+  it('set-speed requires a finite value', () => {
+    let setCalled = false;
+    chrome.storage.sync.set = () => {
+      setCalled = true;
+    };
+
+    bridge = setupMessageBridge();
+    postPageMessage('set-speed', { speed: NaN });
+    expect(setCalled).toBe(false);
+
+    postPageMessage('set-speed', { speed: Infinity });
+    expect(setCalled).toBe(false);
+  });
+
+  it('set-speed requires data to be present', () => {
+    let setCalled = false;
+    chrome.storage.sync.set = () => {
+      setCalled = true;
+    };
+
+    bridge = setupMessageBridge();
+    postPageMessage('set-speed', null);
+
+    expect(setCalled).toBe(false);
+  });
+
+  // --- Only set-speed is accepted from page context ---
+
+  it('only accepts the set-speed action', () => {
+    let setCalled = false;
+    let sendCalled = false;
+    let getCalled = false;
+    chrome.storage.sync.set = () => { setCalled = true; };
+    chrome.storage.sync.get = () => { getCalled = true; };
+    chrome.runtime.sendMessage = () => { sendCalled = true; };
+
+    bridge = setupMessageBridge();
+
+    postPageMessage('storage-update', { lastSpeed: 2.5 });
+    postPageMessage('runtime-message', { type: 'EXTENSION_TOGGLE', enabled: false });
+    postPageMessage('get-storage', {});
+    postPageMessage('something-else', { payload: 'data' });
+
+    expect(setCalled).toBe(false);
+    expect(sendCalled).toBe(false);
+    expect(getCalled).toBe(false);
+  });
+
+  // --- Context invalidation ---
 
   it('Extension context invalidated removes the message listener', () => {
     chrome.storage.sync.set = () => {
@@ -76,7 +147,7 @@ describe('InjectionBridge', () => {
     bridge = setupMessageBridge();
 
     // First message triggers invalidation — listener should self-remove
-    postPageMessage('storage-update', { lastSpeed: 2.0 });
+    postPageMessage('set-speed', { speed: 2.0 });
 
     // Replace with a tracking mock — if listener was removed, this won't fire
     let calledAfter = false;
@@ -84,7 +155,7 @@ describe('InjectionBridge', () => {
       calledAfter = true;
     };
 
-    postPageMessage('storage-update', { lastSpeed: 3.0 });
+    postPageMessage('set-speed', { speed: 3.0 });
 
     expect(calledAfter).toBe(false);
   });
@@ -100,10 +171,46 @@ describe('InjectionBridge', () => {
 
     bridge = setupMessageBridge();
 
-    postPageMessage('storage-update', { lastSpeed: 2.0 });
-    postPageMessage('storage-update', { lastSpeed: 3.0 });
+    postPageMessage('set-speed', { speed: 2.0 });
+    postPageMessage('set-speed', { speed: 3.0 });
 
     expect(callCount).toBe(2);
+  });
+
+  // --- Message source filtering ---
+
+  it('requires vsc-page source prefix', () => {
+    let setCalled = false;
+    chrome.storage.sync.set = () => {
+      setCalled = true;
+    };
+
+    bridge = setupMessageBridge();
+
+    const event = new MessageEvent('message', {
+      data: { source: 'other', action: 'set-speed', data: { speed: 2.0 } },
+    });
+    Object.defineProperty(event, 'source', { value: window });
+    window.dispatchEvent(event);
+
+    expect(setCalled).toBe(false);
+  });
+
+  it('only processes messages from vsc-page, not vsc-content', () => {
+    let setCalled = false;
+    chrome.storage.sync.set = () => {
+      setCalled = true;
+    };
+
+    bridge = setupMessageBridge();
+
+    const event = new MessageEvent('message', {
+      data: { source: 'vsc-content', action: 'set-speed', data: { speed: 2.0 } },
+    });
+    Object.defineProperty(event, 'source', { value: window });
+    window.dispatchEvent(event);
+
+    expect(setCalled).toBe(false);
   });
 
   // --- sendCommand API ---


### PR DESCRIPTION
The message bridge now accepts exactly one page→content verb:
`set-speed` with a validated, clamped numeric value. All persistent
settings writes go through trusted extension contexts (options page,
popup, background) which have direct chrome.storage access.

StorageManager.set() in page context routes only lastSpeed through the
bridge; other keys stay in-memory only.