### PR TITLE
fix: prevent keyboard relative speed baseline reset after tab idle

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -408,17 +408,31 @@ class ActionHandler {
     // Calculate target speed
     let targetSpeed;
     if (relative) {
-      // For relative changes, add to current speed
+      // For relative changes, add to current speed. If the player has silently
+      // reset to 1.0 after idle, but we still have a non-1.0 in-memory speed,
+      // use that remembered baseline for the first relative step.
       const currentSpeed = video.playbackRate < 0.1 ? 0.0 : video.playbackRate;
-      targetSpeed = currentSpeed + value;
+      let baseSpeed = currentSpeed;
+      const rememberedSpeed = this.config?.settings?.lastSpeed;
+      const absDelta = Math.abs(value);
+      const isTypicalStepDelta = absDelta >= 0.05 && absDelta <= 0.5;
+      if (
+        isTypicalStepDelta &&
+        Math.abs(currentSpeed - 1.0) < 0.01 &&
+        typeof rememberedSpeed === 'number' &&
+        Math.abs(rememberedSpeed - 1.0) > 0.01
+      ) {
+        baseSpeed = rememberedSpeed;
+      }
+      targetSpeed = baseSpeed + value;
 
       // Snap to 1.0x when crossing the 1.0 boundary
-      if ((currentSpeed > 1.0 && targetSpeed < 1.0) || (currentSpeed < 1.0 && targetSpeed > 1.0)) {
+      if ((baseSpeed > 1.0 && targetSpeed < 1.0) || (baseSpeed < 1.0 && targetSpeed > 1.0)) {
         targetSpeed = 1.0;
       }
 
       window.VSC.logger.debug(
-        `Relative speed calculation: currentSpeed=${currentSpeed} + ${value} = ${targetSpeed}`
+        `Relative speed calculation: baseSpeed=${baseSpeed} (current=${currentSpeed}) + ${value} = ${targetSpeed}`
       );
     } else {
       // For absolute changes, use value directly
@@ -507,7 +521,7 @@ class ActionHandler {
     speedIndicator.textContent = numericSpeed.toFixed(2);
 
     // 6. Persist to storage only if rememberSpeed is enabled
-    if (source !== 'external' && this.config.settings.rememberSpeed) {
+    if (source !== 'external' && source !== 'init' && this.config.settings.rememberSpeed) {
       this.config.save({ lastSpeed: numericSpeed });
     }
 

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -236,7 +236,8 @@ class VideoController {
       const targetSpeed = this.getTargetSpeed(event.target);
 
       window.VSC.logger.info(`Media event ${event.type}: restoring speed to ${targetSpeed}`);
-      this.actionHandler.adjustSpeed(event.target, targetSpeed, { source: 'internal' });
+      // Treat lifecycle restoration as init-like; do not overwrite lastSpeed.
+      this.actionHandler.adjustSpeed(event.target, targetSpeed, { source: 'init' });
     };
 
     // Bind event handlers

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -410,6 +410,26 @@ describe('ActionHandler', () => {
     expect(mockVideo.playbackRate).toBe(16); // Clamped to max
   });
 
+  it('relative increase should use remembered speed baseline after idle reset to 1.0', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.rememberSpeed = true;
+    config.settings.lastSpeed = 1.5;
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockVideo.vsc = {
+      div: mockDOM.container,
+      speedIndicator: { textContent: '1.00' },
+    };
+
+    actionHandler.adjustSpeed(mockVideo, 0.1, { relative: true });
+    expect(mockVideo.playbackRate).toBe(1.6);
+    expect(config.settings.lastSpeed).toBe(1.6);
+  });
+
   it('adjustSpeed should not corrupt lastSpeed on external changes', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();

--- a/tests/unit/core/video-controller.test.js
+++ b/tests/unit/core/video-controller.test.js
@@ -340,4 +340,31 @@ describe('VideoController', () => {
     const initCall = adjustSpeedCalls.find((call) => call.value === 1.5);
     expect(initCall).toBeDefined();
   });
+
+  it('play event restoration should not overwrite lastSpeed', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.rememberSpeed = true;
+    config.settings.lastSpeed = 1.5;
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({
+      currentSrc: 'https://example.com/video.mp4',
+      playbackRate: 1.5,
+    });
+    mockDOM.container.appendChild(mockVideo);
+
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+    expect(controller).toBeDefined();
+
+    // Simulate player reset during idle/resume, then a play lifecycle event.
+    mockVideo.playbackRate = 1.0;
+    controller.handlePlay({ type: 'play', target: mockVideo });
+
+    // Lifecycle restoration should not replace user-authoritative lastSpeed.
+    expect(config.settings.lastSpeed).toBe(1.5);
+    expect(mockVideo.playbackRate).toBe(1.5);
+  });
 });


### PR DESCRIPTION
Fixes #1494

## Summary

This PR fixes a regression where keyboard relative speed shortcuts (`s` / `d`) could apply from a `1.0x` baseline after tab backgrounding, instead of from the active/effective remembered speed.

### Changes

- Use remembered non-`1.0` speed as baseline for the first relative step when:
  - current playback rate is effectively `1.0`, and
  - delta is a typical shortcut step.
- Treat lifecycle speed restoration as init-like (`source: 'init'`) in media event restore path.
- Do not persist `lastSpeed` for `source: 'init'` updates.

### Why

Lifecycle/init reconciliation should restore playback without mutating user-authoritative remembered speed. If lifecycle restore writes `lastSpeed`, first keyboard relative adjustment can compute from an incorrect `1.0` baseline after idle/background transitions.

## Test Plan

- [x] Added unit test: relative increase uses remembered baseline after idle reset to `1.0`.
- [x] Added unit test: play-event restoration does not overwrite `lastSpeed`.
- [ ] Manual:
  - Enable `rememberSpeed`
  - Set speed to `1.8x`
  - Background tab and return
  - Press `d`/`s`
  - Verify behavior is `1.9x` / `1.7x` (not `1.1x` / `0.9x`)