### PR TITLE
feat: add Crunchyroll support

### DIFF
--- a/src/entries/inject-entry.js
+++ b/src/entries/inject-entry.js
@@ -44,6 +44,7 @@ import '../site-handlers/facebook-handler.js';
 import '../site-handlers/amazon-handler.js';
 import '../site-handlers/apple-handler.js';
 import '../site-handlers/dailymotion-handler.js';
+import '../site-handlers/crunchyroll-handler.js';
 import '../site-handlers/index.js';
 
 // Netflix-specific script

--- a/src/site-handlers/crunchyroll-handler.js
+++ b/src/site-handlers/crunchyroll-handler.js
@@ -1,10 +1,25 @@
 /**
  * Crunchyroll-specific handler
+ *
+ * Crunchyroll uses the Bitmovin player which:
+ * 1. Has overflow:hidden on its container, clipping the controller overlay
+ * 2. Explicitly resets playbackRate on every play/resume via its
+ *    setPlaybackSpeed chain — once synchronously and once via a Promise.
+ *    The synchronous reset overwrites lastSpeed before the extension's
+ *    play event handler runs. We save the speed on pause (before any
+ *    reset can happen) and restore on the playing event, which re-arms
+ *    lastSpeed so the normal fight-back handles the async reset.
  */
 
 window.VSC = window.VSC || {};
 
 class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
+  constructor() {
+    super();
+    this.videoListeners = new Map();
+    this.savedSpeed = null;
+  }
+
   /**
    * Check if this handler applies to Crunchyroll
    * @returns {boolean} True if on Crunchyroll
@@ -15,9 +30,7 @@ class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
 
   /**
    * Get Crunchyroll-specific controller positioning.
-   * Crunchyroll uses the Bitmovin player whose container has overflow:hidden
-   * and a > * rule that collapses children to 0x0. Insert before the container
-   * to escape clipping.
+   * Insert before the Bitmovin container to escape overflow:hidden clipping.
    * @param {HTMLElement} parent - Parent element
    * @param {HTMLElement} _video - Video element
    * @returns {Object} Positioning information
@@ -31,11 +44,54 @@ class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
   }
 
   /**
+   * Set playback rate and register event listeners for speed restoration.
+   * We save the speed on the pause event (before Bitmovin can reset it)
+   * and restore on the playing event (after Bitmovin's reset finishes).
+   * @param {HTMLMediaElement} video - Video element
+   * @param {number} speed - Target speed
+   */
+  handleSpeedChange(video, speed) {
+    video.playbackRate = speed;
+
+    if (video.paused || this.savedSpeed === null) {
+      this.savedSpeed = speed;
+    }
+
+    if (!this.videoListeners.has(video)) {
+      const onPause = () => {
+        this.savedSpeed = video.playbackRate;
+      };
+
+      const onPlaying = () => {
+        if (this.savedSpeed && this.savedSpeed !== video.playbackRate) {
+          const speed = this.savedSpeed;
+          if (video.vsc) {
+            window.VSC_controller.actionHandler.adjustSpeed(video, speed);
+          }
+        }
+      };
+
+      video.addEventListener('pause', onPause);
+      video.addEventListener('playing', onPlaying);
+      this.videoListeners.set(video, { onPause, onPlaying });
+    }
+  }
+
+  /**
    * Get Crunchyroll-specific video container selectors
    * @returns {Array<string>} CSS selectors
    */
   getVideoContainerSelectors() {
     return ['.bitmovinplayer-container'];
+  }
+
+  cleanup() {
+    super.cleanup();
+    this.videoListeners.forEach(({ onPause, onPlaying }, video) => {
+      video.removeEventListener('pause', onPause);
+      video.removeEventListener('playing', onPlaying);
+    });
+    this.videoListeners.clear();
   }
 }
 

--- a/src/site-handlers/crunchyroll-handler.js
+++ b/src/site-handlers/crunchyroll-handler.js
@@ -58,11 +58,11 @@ class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
     }
 
     if (!this.videoListeners.has(video)) {
-      const onPause = () => {
+      const saveSpeed = () => {
         this.savedSpeed = video.playbackRate;
       };
 
-      const onPlaying = () => {
+      const restoreSpeed = () => {
         if (this.savedSpeed && this.savedSpeed !== video.playbackRate) {
           const speed = this.savedSpeed;
           if (video.vsc) {
@@ -71,9 +71,11 @@ class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
         }
       };
 
-      video.addEventListener('pause', onPause);
-      video.addEventListener('playing', onPlaying);
-      this.videoListeners.set(video, { onPause, onPlaying });
+      video.addEventListener('pause', saveSpeed);
+      video.addEventListener('seeking', saveSpeed);
+      video.addEventListener('playing', restoreSpeed);
+      video.addEventListener('seeked', restoreSpeed);
+      this.videoListeners.set(video, { saveSpeed, restoreSpeed });
     }
   }
 
@@ -87,9 +89,11 @@ class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
 
   cleanup() {
     super.cleanup();
-    this.videoListeners.forEach(({ onPause, onPlaying }, video) => {
-      video.removeEventListener('pause', onPause);
-      video.removeEventListener('playing', onPlaying);
+    this.videoListeners.forEach(({ saveSpeed, restoreSpeed }, video) => {
+      video.removeEventListener('pause', saveSpeed);
+      video.removeEventListener('seeking', saveSpeed);
+      video.removeEventListener('playing', restoreSpeed);
+      video.removeEventListener('seeked', restoreSpeed);
     });
     this.videoListeners.clear();
   }

--- a/src/site-handlers/crunchyroll-handler.js
+++ b/src/site-handlers/crunchyroll-handler.js
@@ -1,0 +1,42 @@
+/**
+ * Crunchyroll-specific handler
+ */
+
+window.VSC = window.VSC || {};
+
+class CrunchyrollHandler extends window.VSC.BaseSiteHandler {
+  /**
+   * Check if this handler applies to Crunchyroll
+   * @returns {boolean} True if on Crunchyroll
+   */
+  static matches() {
+    return location.hostname.includes('crunchyroll.com');
+  }
+
+  /**
+   * Get Crunchyroll-specific controller positioning.
+   * Crunchyroll uses the Bitmovin player whose container has overflow:hidden
+   * and a > * rule that collapses children to 0x0. Insert before the container
+   * to escape clipping.
+   * @param {HTMLElement} parent - Parent element
+   * @param {HTMLElement} _video - Video element
+   * @returns {Object} Positioning information
+   */
+  getControllerPosition(parent, _video) {
+    return {
+      insertionPoint: parent,
+      insertionMethod: 'beforeParent',
+      targetParent: parent.parentElement,
+    };
+  }
+
+  /**
+   * Get Crunchyroll-specific video container selectors
+   * @returns {Array<string>} CSS selectors
+   */
+  getVideoContainerSelectors() {
+    return ['.bitmovinplayer-container'];
+  }
+}
+
+window.VSC.CrunchyrollHandler = CrunchyrollHandler;

--- a/src/site-handlers/index.js
+++ b/src/site-handlers/index.js
@@ -14,6 +14,7 @@ class SiteHandlerManager {
       window.VSC.AmazonHandler,
       window.VSC.AppleHandler,
       window.VSC.DailymotionHandler,
+      window.VSC.CrunchyrollHandler,
     ];
   }
 

--- a/tests/helpers/module-loader.js
+++ b/tests/helpers/module-loader.js
@@ -33,6 +33,7 @@ export async function loadCoreModules() {
   await import('../../src/site-handlers/amazon-handler.js');
   await import('../../src/site-handlers/apple-handler.js');
   await import('../../src/site-handlers/dailymotion-handler.js');
+  await import('../../src/site-handlers/crunchyroll-handler.js');
   await import('../../src/site-handlers/index.js');
 
   // Core controllers


### PR DESCRIPTION
## Summary

Adds Crunchyroll support. Crunchyroll uses the Bitmovin player which causes two issues:

- **Overlay not visible**: The Bitmovin container has `overflow: hidden` and a `> *` CSS rule that collapses all direct children to 0x0. The controller is now inserted outside the container to escape clipping (same approach as the Netflix handler).
- **Speed resets on pause/resume and seek**: Bitmovin explicitly resets `playbackRate` on every resume — once synchronously and once via a Promise — and on seeks. This defeats the extension's fight-back mechanism. The handler saves the user's speed on `pause`/`seeking` events and restores it on `playing`/`seeked` events.

## Known limitations

- **Arrow key seek resets speed**: Crunchyroll's native seek (arrow keys) resets the speed to Bitmovin's default. This is because Bitmovin resets `playbackRate` synchronously before the browser's `seeking` event fires, so `savedSpeed` gets overwritten. The extension's own seek keys (Z/X) work correctly since they bypass Bitmovin entirely.
- **Skip intro / chapter transitions**: Seeking to certain timestamps (e.g. where the "Skip Intro" button appears) can cause Crunchyroll's React framework to re-render the player DOM, removing the controller and breaking the extension until page reload. This is a pre-existing issue with how the extension's mutation observer handles aggressive DOM re-renders, not specific to this handler.

## Test plan

- [ ] Load extension, open a Crunchyroll video page
- [ ] Confirm speed overlay appears on the video
- [ ] Set speed to 2x, pause, resume — speed should stay at 2x
- [ ] Change speed while paused, resume — new speed should persist
- [ ] Set Crunchyroll native speed to 0.75x, override with extension to 2x, pause, resume — should stay at 2x
- [ ] Seek with Z/X keys — speed should be preserved
- [ ] Confirm overlay is draggable and doesn't block Crunchyroll's player controls
- [ ] Confirm other sites (YouTube, Netflix) are unaffected