### PR TITLE
[BugFix] - pressing reset key doesn't stick on sites with per-site speed rules

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -471,6 +471,11 @@ class ActionHandler {
     //    default; let the first real user/site action establish authority.
     if (source !== 'external' && source !== 'init') {
       this.config.settings.lastSpeed = numericSpeed;
+      // Mark that the user has made a deliberate speed choice this session.
+      // getTargetSpeed() uses this to distinguish "user chose 1.0" from
+      // "1.0 is just the unset default", so site-rule baselines don't
+      // override an explicit reset.
+      this.config.settings.userSpeedOverride = true;
     }
 
     // 2. Start cooldown — the playbackRate assignment below triggers a

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -108,6 +108,15 @@ class VideoController {
     // current session intent regardless of rememberSpeed (which only controls
     // cross-session STORAGE persistence, not in-memory behavior).
     const last = this.config.settings.lastSpeed;
+    //
+    // userSpeedOverride distinguishes "user explicitly chose 1.0 (e.g. reset)"
+    // from "1.0 is the unset default on fresh load". Without it, pressing reset
+    // on a site with siteDefaultSpeed > 1 gets undone by the next play/seeked
+    // event because getTargetSpeed() falls back to the site baseline.
+    if (this.config.settings.userSpeedOverride) {
+      window.VSC.logger.debug(`Using lastSpeed ${last} (user override, baseline=${baseline})`);
+      return last;
+    }
     if (last && last !== 1.0) {
       window.VSC.logger.debug(`Using lastSpeed ${last} (baseline=${baseline})`);
       return last;

--- a/tests/unit/core/speed-resolution.test.js
+++ b/tests/unit/core/speed-resolution.test.js
@@ -147,4 +147,30 @@ describe('SpeedResolution', () => {
     const ctrl = makeController(config);
     expect(ctrl.getTargetSpeed()).toBe(1.0);
   });
+
+  // --- Bug fix: user reset to 1.0 should stick on sites with per-site default ---
+  it('user reset to 1.0 on site with siteDefaultSpeed=2.0 → 1.0 (not overridden)', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.rememberSpeed = false;
+    config.settings.lastSpeed = 1.0;
+    config.settings.siteDefaultSpeed = 2.0;
+    config.settings.userSpeedOverride = true; // user explicitly chose 1.0
+
+    const ctrl = makeController(config);
+    expect(ctrl.getTargetSpeed()).toBe(1.0);
+  });
+
+  // --- userSpeedOverride=false on fresh load still uses site baseline ---
+  it('fresh load (no user action) with siteDefaultSpeed=2.0 → 2.0', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.rememberSpeed = false;
+    config.settings.lastSpeed = 1.0;
+    config.settings.siteDefaultSpeed = 2.0;
+    config.settings.userSpeedOverride = false;
+
+    const ctrl = makeController(config);
+    expect(ctrl.getTargetSpeed()).toBe(2.0);
+  });
 });


### PR DESCRIPTION
## Summary
- Reset (R key) to 1.0x gets immediately undone on sites with a custom
  speed rule (e.g. youtube.com set to 2.0x)
- The next play/seeked media event snaps speed back to the site default
- Added `userSpeedOverride` flag so the extension knows when a user has
  explicitly chosen a speed vs a fresh page load default

## How to reproduce
1. Go to Options → Site Rules → add `youtube.com` with speed `2.0`
2. Open any YouTube video — confirms it starts at 2.0x
3. Press `R` to reset — speed drops to 1.0x
4. Pause the video, then unpause (or click the scrubber to seek)
5. **Bug:** speed snaps back to 2.0x instead of staying at 1.0x

## Root cause
`getTargetSpeed()` treated `lastSpeed === 1.0` as "no deliberate user
choice" and fell back to the site baseline. Pressing reset IS a deliberate
choice for 1.0, but the code couldn't distinguish it from a fresh page load.

## Fix
- `setSpeed()` now sets `userSpeedOverride = true` on user actions
- `getTargetSpeed()` checks this flag first — if the user has acted,
  return their chosen speed regardless of value
- Flag is session-only (not persisted), so fresh page loads still
  apply site rules correctly

## Tests
- Added: user reset to 1.0 on site with siteDefaultSpeed=2.0 → 1.0
- Added: fresh load (no user action) with siteDefaultSpeed=2.0 → 2.0
- All 358 existing tests pass
