### PR TITLE
Add inline speed slider control

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -505,6 +505,11 @@ class ActionHandler {
     }
     speedIndicator.textContent = numericSpeed.toFixed(2);
 
+    const speedSlider = video.vsc?.speedSlider;
+    if (speedSlider) {
+      speedSlider.value = numericSpeed.toFixed(2);
+    }
+
     // 6. Persist to storage only if rememberSpeed is enabled
     if (source !== 'external' && this.config.settings.rememberSpeed) {
       this.config.save({ lastSpeed: numericSpeed });

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -167,6 +167,7 @@ class VideoController {
 
     // Store speed indicator reference
     this.speedIndicator = window.VSC.ShadowDOMManager.getSpeedIndicator(shadow);
+    this.speedSlider = window.VSC.ShadowDOMManager.getSpeedSlider(shadow);
 
     // Insert into DOM FIRST — position calculation needs the wrapper in the DOM
     this.insertIntoDOM(document, wrapper);

--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -18,6 +18,7 @@ class ControlsManager {
   setupControlEvents(shadow, video) {
     this.setupDragHandler(shadow);
     this.setupButtonHandlers(shadow);
+    this.setupSliderHandler(shadow, video);
     this.setupWheelHandler(shadow, video);
     this.setupClickPrevention(shadow);
   }
@@ -88,16 +89,50 @@ class ControlsManager {
   }
 
   /**
+   * Set up speed slider handlers
+   * @param {ShadowRoot} shadow - Shadow root
+   * @param {HTMLVideoElement} video - Associated video element
+   * @private
+   */
+  setupSliderHandler(shadow, video) {
+    const slider = shadow.querySelector('.speed-slider');
+
+    if (!slider) {
+      return;
+    }
+
+    const handleSliderChange = (e) => {
+      const speed = Number.parseFloat(e.target.value);
+      if (Number.isNaN(speed)) {
+        return;
+      }
+
+      this.actionHandler.adjustSpeed(video, speed, { source: 'internal' });
+      e.stopPropagation();
+    };
+
+    slider.addEventListener('input', handleSliderChange, true);
+    slider.addEventListener('change', handleSliderChange, true);
+    slider.addEventListener(
+      'pointerdown',
+      (e) => {
+        e.stopPropagation();
+      },
+      true
+    );
+  }
+
+  /**
    * Set up mouse wheel handler for speed control with touchpad filtering
-   * 
+   *
    * Cross-browser wheel event behavior:
    * - Chrome/Safari/Edge: ALL devices use DOM_DELTA_PIXEL (mouse wheels ~100px, touchpads ~1-15px)
    * - Firefox: Mouse wheels use DOM_DELTA_LINE, touchpads use DOM_DELTA_PIXEL
-   * 
+   *
    * Detection strategy: Use magnitude threshold in DOM_DELTA_PIXEL mode to distinguish
    * mouse wheels (±100px typical) from touchpads (±1-15px typical). Threshold of 50px
    * provides safety margin based on empirical browser testing.
-   * 
+   *
    * @param {ShadowRoot} shadow - Shadow root
    * @param {HTMLVideoElement} video - Video element
    * @private
@@ -134,7 +169,9 @@ class ControlsManager {
           // Chrome/Safari/Edge: Use magnitude to distinguish mouse wheel (>50px) from touchpad (<50px)
           const TOUCHPAD_THRESHOLD = 50;
           if (Math.abs(event.deltaY) < TOUCHPAD_THRESHOLD) {
-            window.VSC.logger.debug(`Touchpad scroll detected (deltaY: ${event.deltaY}) - ignoring`);
+            window.VSC.logger.debug(
+              `Touchpad scroll detected (deltaY: ${event.deltaY}) - ignoring`
+            );
             return;
           }
         }
@@ -148,7 +185,9 @@ class ControlsManager {
 
         this.actionHandler.adjustSpeed(video, speedDelta, { relative: true });
 
-        window.VSC.logger.debug(`Wheel control: adjusting speed by ${speedDelta} (deltaMode: ${event.deltaMode}, deltaY: ${event.deltaY})`);
+        window.VSC.logger.debug(
+          `Wheel control: adjusting speed by ${speedDelta} (deltaMode: ${event.deltaMode}, deltaY: ${event.deltaY})`
+        );
       },
       { passive: false }
     );

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -84,7 +84,21 @@ class ShadowDOMManager {
         display: none;
         vertical-align: middle;
       }
-      
+
+      .slider-row {
+        display: block;
+        margin: 0 2px 4px 2px;
+        width: 7.5em;
+      }
+
+      .speed-slider {
+        display: block;
+        width: 100%;
+        margin: 0;
+        accent-color: #2196f3;
+        cursor: pointer;
+      }
+
       #controller.dragging {
         cursor: -webkit-grabbing;
         opacity: 0.7;
@@ -146,6 +160,11 @@ class ShadowDOMManager {
       button.rw {
         opacity: 0.65;
       }
+
+      .button-row {
+        display: inline-flex;
+        align-items: center;
+      }
     `;
     shadow.appendChild(style);
 
@@ -167,6 +186,24 @@ class ShadowDOMManager {
     controls.id = 'controls';
     controls.style.cssText = `font-size: ${buttonSize}px; line-height: ${buttonSize}px;`;
 
+    const sliderRow = document.createElement('div');
+    sliderRow.className = 'slider-row';
+
+    const speedSlider = document.createElement('input');
+    speedSlider.type = 'range';
+    speedSlider.className = 'speed-slider';
+    speedSlider.min = '0.5';
+    speedSlider.max = '4';
+    speedSlider.step = '0.1';
+    speedSlider.value = speed;
+    speedSlider.setAttribute('aria-label', 'Playback speed');
+    sliderRow.appendChild(speedSlider);
+
+    controls.appendChild(sliderRow);
+
+    const buttonRow = document.createElement('span');
+    buttonRow.className = 'button-row';
+
     // Create buttons
     const buttons = [
       { action: 'rewind', text: '«', class: 'rw' },
@@ -182,8 +219,10 @@ class ShadowDOMManager {
         button.className = btnConfig.class;
       }
       button.textContent = btnConfig.text;
-      controls.appendChild(button);
+      buttonRow.appendChild(button);
     });
+
+    controls.appendChild(buttonRow);
 
     controller.appendChild(controls);
     shadow.appendChild(controller);
@@ -217,6 +256,15 @@ class ShadowDOMManager {
    */
   static getSpeedIndicator(shadow) {
     return shadow.querySelector('.draggable');
+  }
+
+  /**
+   * Get speed slider from shadow DOM
+   * @param {ShadowRoot} shadow - Shadow root
+   * @returns {HTMLInputElement | null} Speed slider element
+   */
+  static getSpeedSlider(shadow) {
+    return shadow.querySelector('.speed-slider');
   }
 
   /**

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -85,7 +85,7 @@ class ShadowDOMManager {
         vertical-align: middle;
       }
 
-      .slider-row {
+      .speed-slider-row {
         display: block;
         margin: 0 2px 4px 2px;
         width: 7.5em;
@@ -186,8 +186,8 @@ class ShadowDOMManager {
     controls.id = 'controls';
     controls.style.cssText = `font-size: ${buttonSize}px; line-height: ${buttonSize}px;`;
 
-    const sliderRow = document.createElement('div');
-    sliderRow.className = 'slider-row';
+    const speedSliderRow = document.createElement('div');
+    speedSliderRow.className = 'speed-slider-row';
 
     const speedSlider = document.createElement('input');
     speedSlider.type = 'range';
@@ -197,9 +197,9 @@ class ShadowDOMManager {
     speedSlider.step = '0.1';
     speedSlider.value = speed;
     speedSlider.setAttribute('aria-label', 'Playback speed');
-    sliderRow.appendChild(speedSlider);
+    speedSliderRow.appendChild(speedSlider);
 
-    controls.appendChild(sliderRow);
+    controls.appendChild(speedSliderRow);
 
     const buttonRow = document.createElement('span');
     buttonRow.className = 'button-row';

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -79,6 +79,7 @@ describe('ActionHandler', () => {
     expect(mockVideo.playbackRate).toBe(2.0);
     expect(mockVideo.vsc.speedIndicator.textContent).toBe('2.00');
     expect(config.settings.lastSpeed).toBe(2.0);
+    expect(mockVideo.vsc.speedSlider.value).toBe('2.00');
   });
 
   it('ActionHandler should handle faster action', async () => {
@@ -428,14 +429,17 @@ describe('ActionHandler', () => {
     actionHandler.adjustSpeed(mockVideo, 1.5);
     expect(mockVideo.playbackRate).toBe(1.5);
     expect(mockVideo.vsc.speedIndicator.textContent).toBe('1.50');
+    expect(mockVideo.vsc.speedSlider.value).toBe('1.50');
     expect(config.settings.lastSpeed).toBe(1.5);
 
     // Test speed limits
     actionHandler.adjustSpeed(mockVideo, 20); // Above max
     expect(mockVideo.playbackRate).toBe(16); // Clamped to max
+    expect(mockVideo.vsc.speedSlider.value).toBe('16.00');
 
     actionHandler.adjustSpeed(mockVideo, 0.01); // Below min
     expect(mockVideo.playbackRate).toBe(0.07); // Clamped to min
+    expect(mockVideo.vsc.speedSlider.value).toBe('0.07');
   });
 
   it('adjustSpeed should handle relative speed changes', async () => {

--- a/tests/unit/ui/drag-and-reset.test.js
+++ b/tests/unit/ui/drag-and-reset.test.js
@@ -144,4 +144,45 @@ describe('DragAndReset', () => {
     const style = controller.div.shadowRoot.querySelector('style');
     expect(style.textContent.includes('touch-action: none')).toBe(true);
   });
+
+  it('controller renders a speed slider above the existing buttons', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.25 });
+    mockDOM.container.appendChild(mockVideo);
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    const controls = controller.div.shadowRoot.querySelector('#controls');
+    const sliderRow = controls.firstElementChild;
+    const buttonRow = controls.lastElementChild;
+    const slider = controller.div.shadowRoot.querySelector('.speed-slider');
+
+    expect(slider).toBeTruthy();
+    expect(sliderRow.className).toBe('slider-row');
+    expect(buttonRow.className).toBe('button-row');
+    expect(slider.value).toBe('1.25');
+    expect(slider.min).toBe('0.5');
+    expect(buttonRow.querySelectorAll('button')).toHaveLength(4);
+  });
+
+  it('speed slider changes playback speed without affecting drag behavior', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockDOM.container.appendChild(mockVideo);
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    const slider = controller.div.shadowRoot.querySelector('.speed-slider');
+    slider.value = '1.75';
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(mockVideo.playbackRate).toBe(1.75);
+    expect(controller.speedIndicator.textContent).toBe('1.75');
+  });
 });

--- a/tests/unit/ui/drag-and-reset.test.js
+++ b/tests/unit/ui/drag-and-reset.test.js
@@ -156,12 +156,12 @@ describe('DragAndReset', () => {
     const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
 
     const controls = controller.div.shadowRoot.querySelector('#controls');
-    const sliderRow = controls.firstElementChild;
+    const speedSliderRow = controls.firstElementChild;
     const buttonRow = controls.lastElementChild;
     const slider = controller.div.shadowRoot.querySelector('.speed-slider');
 
     expect(slider).toBeTruthy();
-    expect(sliderRow.className).toBe('slider-row');
+    expect(speedSliderRow.className).toBe('speed-slider-row');
     expect(buttonRow.className).toBe('button-row');
     expect(slider.value).toBe('1.25');
     expect(slider.min).toBe('0.5');


### PR DESCRIPTION
Adds a small speed slider above the existing controller buttons and wires it into the current speed-change flow.

I found this useful for quicker direct speed selection, but I’m not sure whether this is something you’d want in the main controller UI, so I wanted to open it up for feedback first.

If this direction makes sense, this could also be made optional behind a setting so users can enable or disable it.


https://github.com/user-attachments/assets/31167d75-cd80-4b70-a6bf-89652927c0e9


