### PR TITLE
Add 1x quick reset button

### DIFF
--- a/src/ui/controls.js
+++ b/src/ui/controls.js
@@ -17,7 +17,7 @@ class ControlsManager {
    */
   setupControlEvents(shadow, video) {
     this.setupDragHandler(shadow);
-    this.setupButtonHandlers(shadow);
+    this.setupButtonHandlers(shadow, video);
     this.setupWheelHandler(shadow, video);
     this.setupClickPrevention(shadow);
   }
@@ -60,17 +60,28 @@ class ControlsManager {
    * @param {ShadowRoot} shadow - Shadow root
    * @private
    */
-  setupButtonHandlers(shadow) {
+  setupButtonHandlers(shadow, video) {
     shadow.querySelectorAll('button').forEach((button) => {
       // Click handler
       button.addEventListener(
         'click',
         (e) => {
+          const directSpeed = button.dataset['speed'];
+          if (directSpeed !== undefined) {
+            this.actionHandler.adjustSpeed(video, Number.parseFloat(directSpeed), {
+              source: 'internal',
+            });
+            e.preventDefault();
+            e.stopPropagation();
+            return;
+          }
+
           this.actionHandler.runAction(
-            e.target.dataset['action'],
-            this.config.getKeyBinding(e.target.dataset['action']),
+            button.dataset['action'],
+            this.config.getKeyBinding(button.dataset['action']),
             e
           );
+          e.preventDefault();
           e.stopPropagation();
         },
         true
@@ -89,15 +100,15 @@ class ControlsManager {
 
   /**
    * Set up mouse wheel handler for speed control with touchpad filtering
-   * 
+   *
    * Cross-browser wheel event behavior:
    * - Chrome/Safari/Edge: ALL devices use DOM_DELTA_PIXEL (mouse wheels ~100px, touchpads ~1-15px)
    * - Firefox: Mouse wheels use DOM_DELTA_LINE, touchpads use DOM_DELTA_PIXEL
-   * 
+   *
    * Detection strategy: Use magnitude threshold in DOM_DELTA_PIXEL mode to distinguish
    * mouse wheels (±100px typical) from touchpads (±1-15px typical). Threshold of 50px
    * provides safety margin based on empirical browser testing.
-   * 
+   *
    * @param {ShadowRoot} shadow - Shadow root
    * @param {HTMLVideoElement} video - Video element
    * @private
@@ -134,7 +145,9 @@ class ControlsManager {
           // Chrome/Safari/Edge: Use magnitude to distinguish mouse wheel (>50px) from touchpad (<50px)
           const TOUCHPAD_THRESHOLD = 50;
           if (Math.abs(event.deltaY) < TOUCHPAD_THRESHOLD) {
-            window.VSC.logger.debug(`Touchpad scroll detected (deltaY: ${event.deltaY}) - ignoring`);
+            window.VSC.logger.debug(
+              `Touchpad scroll detected (deltaY: ${event.deltaY}) - ignoring`
+            );
             return;
           }
         }
@@ -148,7 +161,9 @@ class ControlsManager {
 
         this.actionHandler.adjustSpeed(video, speedDelta, { relative: true });
 
-        window.VSC.logger.debug(`Wheel control: adjusting speed by ${speedDelta} (deltaMode: ${event.deltaMode}, deltaY: ${event.deltaY})`);
+        window.VSC.logger.debug(
+          `Wheel control: adjusting speed by ${speedDelta} (deltaMode: ${event.deltaMode}, deltaY: ${event.deltaY})`
+        );
       },
       { passive: false }
     );

--- a/src/ui/shadow-dom.js
+++ b/src/ui/shadow-dom.js
@@ -175,9 +175,17 @@ class ShadowDOMManager {
       { action: 'advance', text: '»', class: 'rw' },
     ];
 
+    buttons.splice(2, 0, { speed: '1', text: '1x', class: '' });
+
     buttons.forEach((btnConfig) => {
       const button = document.createElement('button');
-      button.setAttribute('data-action', btnConfig.action);
+      if (btnConfig.action) {
+        button.setAttribute('data-action', btnConfig.action);
+      }
+      if (btnConfig.speed) {
+        button.setAttribute('data-speed', btnConfig.speed);
+        button.setAttribute('aria-label', 'Set playback speed to 1x');
+      }
       if (btnConfig.class) {
         button.className = btnConfig.class;
       }

--- a/tests/unit/ui/drag-and-reset.test.js
+++ b/tests/unit/ui/drag-and-reset.test.js
@@ -144,4 +144,41 @@ describe('DragAndReset', () => {
     const style = controller.div.shadowRoot.querySelector('style');
     expect(style.textContent.includes('touch-action: none')).toBe(true);
   });
+
+  it('controller renders a 1x button between slower and faster', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.25 });
+    mockDOM.container.appendChild(mockVideo);
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    const buttons = controller.div.shadowRoot.querySelectorAll('#controls button');
+    const quickSpeedButton = controller.div.shadowRoot.querySelector('button[data-speed="1"]');
+
+    expect(quickSpeedButton).toBeTruthy();
+    expect(buttons).toHaveLength(5);
+    expect(buttons[1].dataset.action).toBe('slower');
+    expect(buttons[2].textContent).toBe('1x');
+    expect(buttons[3].dataset.action).toBe('faster');
+  });
+
+  it('quick 1x button restores normal playback speed', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({ playbackRate: 2.0 });
+    mockDOM.container.appendChild(mockVideo);
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    const quickSpeedButton = controller.div.shadowRoot.querySelector('button[data-speed="1"]');
+    quickSpeedButton.dispatchEvent(new Event('click', { bubbles: true }));
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(controller.speedIndicator.textContent).toBe('1.00');
+  });
 });


### PR DESCRIPTION
Adds a small speed slider above the existing controller buttons and wires it into the current speed-change flow.

I found this useful for quicker direct speed selection, but I’m not sure whether this is something you’d want in the main controller UI, so I wanted to open it up for feedback first.

If this direction makes sense, this could also be made optional behind a setting so users can enable or disable it.


https://github.com/user-attachments/assets/234499db-2e57-4045-9674-fb38976ec3f3

