### PR TITLE
fix(youtube): support click+hold interactions as user-intentional rate-changes

### DIFF
--- a/src/utils/event-manager.js
+++ b/src/utils/event-manager.js
@@ -23,6 +23,12 @@ class EventManager {
     // USER_GESTURE_WINDOW_MS of this is treated as intentional and accepted
     // immediately rather than fought — handles native site speed controls.
     this.lastUserInteractionAt = 0;
+
+    // User gesture tracking: whether a click is currently being held down.
+    // This is used in combination with lastUserInteractionAt to accept intentional
+    // rate changes during click-and-hold interactions with site controls that
+    // would otherwise fail to update lastUserInteractionAt until click release.
+    this.isClickHeld = false;
   }
 
   /**
@@ -225,14 +231,25 @@ class EventManager {
       if (event.target?.closest?.('vsc-controller')) {
         return;
       }
+
+      // Click events are fired on release, so pointerdown = held; click = not-held
+      this.isClickHeld = event.type === 'pointerdown';
       this.lastUserInteractionAt = event.timeStamp;
     };
+
+    document.addEventListener('pointerdown', clickHandler, true);
     document.addEventListener('click', clickHandler, true);
 
     if (!this.listeners.has(document)) {
       this.listeners.set(document, []);
     }
-    this.listeners.get(document).push({ type: 'click', handler: clickHandler, useCapture: true });
+
+    this.listeners
+      .get(document)
+      .push(
+        { type: 'pointerdown', handler: clickHandler, useCapture: true },
+        { type: 'click', handler: clickHandler, useCapture: true }
+      );
   }
 
   /**
@@ -330,7 +347,8 @@ class EventManager {
 
     if (authoritativeSpeed && Math.abs(video.playbackRate - authoritativeSpeed) > 0.01) {
       const timeSinceGesture = event.timeStamp - this.lastUserInteractionAt;
-      const isUserGesture = timeSinceGesture < EventManager.USER_GESTURE_WINDOW_MS;
+      const isUserGesture =
+        timeSinceGesture < EventManager.USER_GESTURE_WINDOW_MS || this.isClickHeld;
 
       if (isUserGesture) {
         // User interacted with the site's native controls — accept immediately.


### PR DESCRIPTION
## What
This PR adjusts the handling of user gesture tracking in the `EventManager` class to support click-and-hold interactions with site controls. Fixes #1554 

## Why
YouTube allows users to click-and-hold for a temporary 2x speed boost, but `handleRateChange()` was overriding the update due to `lastUserInteractionAt` only using `click` events to detect mouse interactions.

As `click` only fires after an entire mouse-down -> mouse-up cycle completes, `lastUserInteractionAt` wasn't being set until *after* the user released the button press. Now, `clickHandler` is called on `pointerdown`, too, setting `lastUserInteractionAt` and updating a new `isClickHeld` flag that is included in `handleRateChange()`'s logic.

## How
- Added an `isClickHeld` property to `EventManager` to track whether the most recent mouse interaction is currently held down.
  - The value of `isClickHeld` is updated based on the most recent `event.type` received by `clickHandler`.
- Added a `pointerdown` event listener to pair with the existing `click` listener for `clickHandler`.
- Modified the logic for determining if a playback rate change is a user gesture.
  - Now considers either a recent interaction *or* an ongoing click-and-hold as valid user gestures.