### PR TITLE
Add pause-resume live stream catch-up

### DIFF
--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -206,6 +206,11 @@ class ActionHandler {
    * @returns {number|null} Seconds behind the live edge, or null if not live
    */
   getLiveLatency(video) {
+    const siteLatency = window.VSC.siteHandlerManager?.getLiveLatency(video);
+    if (siteLatency !== null && siteLatency !== undefined) {
+      return siteLatency;
+    }
+
     const ranges = video.seekable;
 
     if (!ranges || ranges.length === 0) {
@@ -223,9 +228,6 @@ class ActionHandler {
     const isUnboundedDuration =
       video.duration === Infinity || video.duration === undefined || Number.isNaN(video.duration);
     const hasSlidingSeekableWindow = Number.isFinite(liveStart) && liveStart > 0;
-    const isYouTubeLive =
-      window.location.hostname.endsWith('youtube.com') &&
-      Boolean(video.ownerDocument.querySelector('.ytp-live-badge, .ytp-live'));
     const previousLiveEdge = video.vsc?.lastLiveEdge;
     const liveEdgeAdvanced =
       Number.isFinite(previousLiveEdge) && liveEdge > previousLiveEdge + 0.25;
@@ -234,7 +236,7 @@ class ActionHandler {
       video.vsc.lastLiveEdge = liveEdge;
     }
 
-    if (!isUnboundedDuration && !hasSlidingSeekableWindow && !isYouTubeLive && !liveEdgeAdvanced) {
+    if (!isUnboundedDuration && !hasSlidingSeekableWindow && !liveEdgeAdvanced) {
       return null;
     }
 

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -259,6 +259,10 @@ class ActionHandler {
       return;
     }
 
+    if (!catchUpEnabled) {
+      controller.liveCatchUpActive = false;
+    }
+
     if (!catchUpEnabled && !resetAtEdge) {
       return;
     }
@@ -296,6 +300,10 @@ class ActionHandler {
     }
 
     if (catchUpEnabled && latency > startThreshold) {
+      if (controller.liveCatchUpActive) {
+        return;
+      }
+
       controller.liveCatchUpActive = true;
       if (Math.abs(video.playbackRate - catchUpSpeed) > 0.01) {
         window.VSC.logger.info(`Live catch-up active: ${latency.toFixed(1)}s behind live`);
@@ -304,10 +312,16 @@ class ActionHandler {
       return;
     }
 
-    if ((controller.liveCatchUpActive || resetAtEdge) && isNearLive && video.playbackRate > 1.0) {
-      window.VSC.logger.info('Live edge reached; restoring speed to 1x');
+    if (isNearLive) {
+      const shouldResetSpeed =
+        (controller.liveCatchUpActive || resetAtEdge) && video.playbackRate > 1.0;
+
       controller.liveCatchUpActive = false;
-      this.adjustSpeed(video, 1.0, { source: 'liveCatchUp' });
+
+      if (shouldResetSpeed) {
+        window.VSC.logger.info('Live edge reached; restoring speed to 1x');
+        this.adjustSpeed(video, 1.0, { source: 'liveCatchUp' });
+      }
       return;
     }
 

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -199,6 +199,80 @@ class ActionHandler {
   }
 
   /**
+   * Get how far playback is from the end of a live stream's seekable range.
+   * Returns null for normal on-demand videos to avoid treating "time left" as
+   * live latency.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {number|null} Seconds behind the live edge, or null if not live
+   */
+  getLiveLatency(video) {
+    const ranges = video.seekable;
+    const isProbablyLive =
+      video.duration === Infinity || video.duration === undefined || Number.isNaN(video.duration);
+
+    if (!isProbablyLive || !ranges || ranges.length === 0) {
+      return null;
+    }
+
+    const liveEdge = ranges.end(ranges.length - 1);
+    if (!Number.isFinite(liveEdge)) {
+      return null;
+    }
+
+    return Math.max(0, liveEdge - video.currentTime);
+  }
+
+  /**
+   * Automatically catch up to the live edge, and optionally reset manual
+   * speeds above 1x once playback reaches the live edge.
+   * @param {HTMLMediaElement} video - Video element
+   */
+  updateLiveCatchUp(video) {
+    const settings = this.config.settings;
+    const controller = video.vsc;
+    const catchUpEnabled = Boolean(settings.liveCatchUpEnabled);
+    const resetAtEdge = Boolean(settings.liveResetSpeedAtEdge);
+
+    if (!controller || (!catchUpEnabled && !resetAtEdge)) {
+      return;
+    }
+
+    const latency = this.getLiveLatency(video);
+    if (latency === null || video.paused) {
+      return;
+    }
+
+    const numericSetting = (value, fallback) => {
+      const number = Number(value);
+      return Number.isFinite(number) ? number : fallback;
+    };
+    const catchUpSpeed = numericSetting(settings.liveCatchUpSpeed, 1.5);
+    const startThreshold = numericSetting(settings.liveCatchUpStartThreshold, 10);
+    const stopThreshold = numericSetting(settings.liveCatchUpStopThreshold, 3);
+    const isNearLive = latency <= stopThreshold;
+
+    if (catchUpEnabled && latency > startThreshold) {
+      controller.liveCatchUpActive = true;
+      if (Math.abs(video.playbackRate - catchUpSpeed) > 0.01) {
+        window.VSC.logger.info(`Live catch-up active: ${latency.toFixed(1)}s behind live`);
+        this.adjustSpeed(video, catchUpSpeed, { source: 'liveCatchUp' });
+      }
+      return;
+    }
+
+    if ((controller.liveCatchUpActive || resetAtEdge) && isNearLive && video.playbackRate > 1.0) {
+      window.VSC.logger.info('Live edge reached; restoring speed to 1x');
+      controller.liveCatchUpActive = false;
+      this.adjustSpeed(video, 1.0, { source: 'liveCatchUp' });
+      return;
+    }
+
+    if (controller.liveCatchUpActive && !catchUpEnabled) {
+      controller.liveCatchUpActive = false;
+    }
+  }
+
+  /**
    * Reset speed with memory toggle functionality.
    *
    * Behavior:
@@ -468,7 +542,7 @@ class ActionHandler {
     //    undoes the very change we're making.
     //    'init' source: skip — don't arm fight-back with the initialization
     //    default; let the first real user/site action establish authority.
-    if (source !== 'external' && source !== 'init') {
+    if (source !== 'external' && source !== 'init' && source !== 'liveCatchUp') {
       this.config.settings.lastSpeed = numericSpeed;
     }
 
@@ -506,7 +580,7 @@ class ActionHandler {
     speedIndicator.textContent = numericSpeed.toFixed(2);
 
     // 6. Persist to storage only if rememberSpeed is enabled
-    if (source !== 'external' && this.config.settings.rememberSpeed) {
+    if (source !== 'external' && source !== 'liveCatchUp' && this.config.settings.rememberSpeed) {
       this.config.save({ lastSpeed: numericSpeed });
     }
 

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -180,6 +180,7 @@ class ActionHandler {
    * @param {number} seekSeconds - Seconds to seek
    */
   seek(video, seekSeconds) {
+    this.handleLiveSeek(video);
     // Use site-specific seeking (handlers return true if they handle it)
     window.VSC.siteHandlerManager.handleSeek(video, seekSeconds);
   }
@@ -244,6 +245,138 @@ class ActionHandler {
   }
 
   /**
+   * Parse a numeric setting with a fallback.
+   * @param {*} value - Setting value
+   * @param {number} fallback - Default value
+   * @returns {number}
+   * @private
+   */
+  numericSetting(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+  }
+
+  /**
+   * Clear all transient live catch-up state for a media element.
+   * @param {HTMLMediaElement} video - Video element
+   */
+  clearLiveCatchUpState(video) {
+    const controller = video?.vsc;
+    if (!controller) {
+      return;
+    }
+
+    controller.liveCatchUpActive = false;
+    controller.liveCatchUpPauseCandidate = null;
+    controller.liveCatchUpResumeCandidate = null;
+  }
+
+  /**
+   * Record whether a pause happened close enough to live to allow catch-up after resume.
+   * @param {HTMLMediaElement} video - Video element
+   */
+  handleLivePause(video) {
+    const controller = video?.vsc;
+    if (!controller || !this.config.settings.liveCatchUpEnabled) {
+      this.clearLiveCatchUpState(video);
+      return;
+    }
+
+    const latency = this.getLiveLatency(video);
+    if (latency === null) {
+      this.clearLiveCatchUpState(video);
+      return;
+    }
+
+    const nearLiveThreshold = this.numericSetting(
+      this.config.settings.liveCatchUpPauseNearLiveThreshold,
+      900
+    );
+    const wasCatchUpActive = Boolean(controller.liveCatchUpActive);
+
+    if (!wasCatchUpActive && latency > nearLiveThreshold) {
+      this.clearLiveCatchUpState(video);
+      return;
+    }
+
+    controller.liveCatchUpPauseCandidate = {
+      pausedAt: Date.now(),
+      latencyAtPause: latency,
+      seekGeneration: controller.liveCatchUpSeekGeneration,
+      wasCatchUpActive,
+    };
+    controller.liveCatchUpResumeCandidate = null;
+  }
+
+  /**
+   * Convert a valid pause candidate into a short-lived resume candidate.
+   * @param {HTMLMediaElement} video - Video element
+   */
+  handleLivePlay(video) {
+    const controller = video?.vsc;
+    if (!controller || !this.config.settings.liveCatchUpEnabled) {
+      this.clearLiveCatchUpState(video);
+      return;
+    }
+
+    const pauseCandidate = controller.liveCatchUpPauseCandidate;
+    if (!pauseCandidate || pauseCandidate.seekGeneration !== controller.liveCatchUpSeekGeneration) {
+      this.clearLiveCatchUpState(video);
+      return;
+    }
+
+    controller.liveCatchUpResumeCandidate = {
+      resumedAt: Date.now(),
+      seekGeneration: controller.liveCatchUpSeekGeneration,
+      latencyAtPause: pauseCandidate.latencyAtPause,
+    };
+    controller.liveCatchUpPauseCandidate = null;
+
+    if (pauseCandidate.wasCatchUpActive) {
+      controller.liveCatchUpActive = false;
+    }
+  }
+
+  /**
+   * Invalidate catch-up intent when the user seeks manually.
+   * @param {HTMLMediaElement} video - Video element
+   */
+  handleLiveSeek(video) {
+    const controller = video?.vsc;
+    if (!controller) {
+      return;
+    }
+
+    controller.liveCatchUpSeekGeneration = (controller.liveCatchUpSeekGeneration || 0) + 1;
+    this.clearLiveCatchUpState(video);
+  }
+
+  /**
+   * Check whether catch-up may be started for this resume window.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {boolean}
+   * @private
+   */
+  hasValidLiveCatchUpResumeCandidate(video) {
+    const controller = video?.vsc;
+    const candidate = controller?.liveCatchUpResumeCandidate;
+    if (!controller || !candidate) {
+      return false;
+    }
+
+    const maxAgeMs = 30000;
+    const isValid =
+      candidate.seekGeneration === controller.liveCatchUpSeekGeneration &&
+      Date.now() - candidate.resumedAt <= maxAgeMs;
+
+    if (!isValid) {
+      controller.liveCatchUpResumeCandidate = null;
+    }
+
+    return isValid;
+  }
+
+  /**
    * Automatically catch up to the live edge, and optionally reset manual
    * speeds above 1x once playback reaches the live edge.
    * @param {HTMLMediaElement} video - Video element
@@ -260,7 +393,7 @@ class ActionHandler {
     }
 
     if (!catchUpEnabled) {
-      controller.liveCatchUpActive = false;
+      this.clearLiveCatchUpState(video);
     }
 
     if (!catchUpEnabled && !resetAtEdge) {
@@ -269,6 +402,7 @@ class ActionHandler {
 
     const latency = this.getLiveLatency(video);
     if (latency === null) {
+      this.clearLiveCatchUpState(video);
       window.VSC.logger.debug(
         `Live catch-up skipped: not detected as live (duration=${video.duration}, seekable=${video.seekable?.length || 0})`
       );
@@ -282,13 +416,9 @@ class ActionHandler {
       return;
     }
 
-    const numericSetting = (value, fallback) => {
-      const number = Number(value);
-      return Number.isFinite(number) ? number : fallback;
-    };
-    const catchUpSpeed = numericSetting(settings.liveCatchUpSpeed, 1.5);
-    const startThreshold = numericSetting(settings.liveCatchUpStartThreshold, 10);
-    const stopThreshold = numericSetting(settings.liveCatchUpStopThreshold, 3);
+    const catchUpSpeed = this.numericSetting(settings.liveCatchUpSpeed, 1.5);
+    const startThreshold = this.numericSetting(settings.liveCatchUpStartThreshold, 10);
+    const stopThreshold = this.numericSetting(settings.liveCatchUpStopThreshold, 3);
     const isNearLive = latency <= stopThreshold;
     const now = Date.now();
 
@@ -304,7 +434,12 @@ class ActionHandler {
         return;
       }
 
+      if (!this.hasValidLiveCatchUpResumeCandidate(video)) {
+        return;
+      }
+
       controller.liveCatchUpActive = true;
+      controller.liveCatchUpResumeCandidate = null;
       if (Math.abs(video.playbackRate - catchUpSpeed) > 0.01) {
         window.VSC.logger.info(`Live catch-up active: ${latency.toFixed(1)}s behind live`);
         this.adjustSpeed(video, catchUpSpeed, { source: 'liveCatchUp' });
@@ -316,17 +451,12 @@ class ActionHandler {
       const shouldResetSpeed =
         (controller.liveCatchUpActive || resetAtEdge) && video.playbackRate > 1.0;
 
-      controller.liveCatchUpActive = false;
+      this.clearLiveCatchUpState(video);
 
       if (shouldResetSpeed) {
         window.VSC.logger.info('Live edge reached; restoring speed to 1x');
         this.adjustSpeed(video, 1.0, { source: 'liveCatchUp' });
       }
-      return;
-    }
-
-    if (controller.liveCatchUpActive && !catchUpEnabled) {
-      controller.liveCatchUpActive = false;
     }
   }
 
@@ -602,6 +732,7 @@ class ActionHandler {
     //    default; let the first real user/site action establish authority.
     if (source !== 'external' && source !== 'init' && source !== 'liveCatchUp') {
       this.config.settings.lastSpeed = numericSpeed;
+      this.clearLiveCatchUpState(video);
     }
 
     // 2. Start cooldown — the playbackRate assignment below triggers a

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -207,15 +207,34 @@ class ActionHandler {
    */
   getLiveLatency(video) {
     const ranges = video.seekable;
-    const isProbablyLive =
-      video.duration === Infinity || video.duration === undefined || Number.isNaN(video.duration);
 
-    if (!isProbablyLive || !ranges || ranges.length === 0) {
+    if (!ranges || ranges.length === 0) {
       return null;
     }
 
-    const liveEdge = ranges.end(ranges.length - 1);
+    const firstRange = 0;
+    const lastRange = ranges.length - 1;
+    const liveStart = ranges.start(firstRange);
+    const liveEdge = ranges.end(lastRange);
     if (!Number.isFinite(liveEdge)) {
+      return null;
+    }
+
+    const isUnboundedDuration =
+      video.duration === Infinity || video.duration === undefined || Number.isNaN(video.duration);
+    const hasSlidingSeekableWindow = Number.isFinite(liveStart) && liveStart > 0;
+    const isYouTubeLive =
+      window.location.hostname.endsWith('youtube.com') &&
+      Boolean(video.ownerDocument.querySelector('.ytp-live-badge, .ytp-live'));
+    const previousLiveEdge = video.vsc?.lastLiveEdge;
+    const liveEdgeAdvanced =
+      Number.isFinite(previousLiveEdge) && liveEdge > previousLiveEdge + 0.25;
+
+    if (video.vsc) {
+      video.vsc.lastLiveEdge = liveEdge;
+    }
+
+    if (!isUnboundedDuration && !hasSlidingSeekableWindow && !isYouTubeLive && !liveEdgeAdvanced) {
       return null;
     }
 
@@ -233,12 +252,27 @@ class ActionHandler {
     const catchUpEnabled = Boolean(settings.liveCatchUpEnabled);
     const resetAtEdge = Boolean(settings.liveResetSpeedAtEdge);
 
-    if (!controller || (!catchUpEnabled && !resetAtEdge)) {
+    if (!controller) {
+      window.VSC.logger.debug('Live catch-up skipped: no controller attached');
+      return;
+    }
+
+    if (!catchUpEnabled && !resetAtEdge) {
       return;
     }
 
     const latency = this.getLiveLatency(video);
-    if (latency === null || video.paused) {
+    if (latency === null) {
+      window.VSC.logger.debug(
+        `Live catch-up skipped: not detected as live (duration=${video.duration}, seekable=${video.seekable?.length || 0})`
+      );
+      return;
+    }
+
+    if (video.paused) {
+      window.VSC.logger.debug(
+        `Live catch-up skipped: video paused (${latency.toFixed(1)}s behind)`
+      );
       return;
     }
 
@@ -250,6 +284,14 @@ class ActionHandler {
     const startThreshold = numericSetting(settings.liveCatchUpStartThreshold, 10);
     const stopThreshold = numericSetting(settings.liveCatchUpStopThreshold, 3);
     const isNearLive = latency <= stopThreshold;
+    const now = Date.now();
+
+    if (!controller.lastLiveCatchUpLogAt || now - controller.lastLiveCatchUpLogAt > 2000) {
+      controller.lastLiveCatchUpLogAt = now;
+      window.VSC.logger.debug(
+        `Live catch-up check: latency=${latency.toFixed(1)}s, speed=${video.playbackRate}, start=${startThreshold}s, stop=${stopThreshold}s, active=${Boolean(controller.liveCatchUpActive)}`
+      );
+    }
 
     if (catchUpEnabled && latency > startThreshold) {
       controller.liveCatchUpActive = true;

--- a/src/core/action-handler.js
+++ b/src/core/action-handler.js
@@ -739,7 +739,7 @@ class ActionHandler {
     //    native ratechange event synchronously. Without cooldown active,
     //    handleRateChange would misclassify it as an external site change.
     if (this.eventManager) {
-      this.eventManager.refreshCoolDown();
+      this.eventManager.refreshCoolDown(undefined, numericSpeed);
     }
 
     // 3. Set the actual playback rate via site handler (native ratechange fires here, blocked by cooldown)

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -163,6 +163,9 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.liveCatchUpSpeed = Number(storage.liveCatchUpSpeed);
         this.settings.liveCatchUpStartThreshold = Number(storage.liveCatchUpStartThreshold);
         this.settings.liveCatchUpStopThreshold = Number(storage.liveCatchUpStopThreshold);
+        this.settings.liveCatchUpPauseNearLiveThreshold = Number(
+          storage.liveCatchUpPauseNearLiveThreshold
+        );
         this.settings.liveResetSpeedAtEdge = Boolean(storage.liveResetSpeedAtEdge);
         this.settings.controllerOpacity = Number(storage.controllerOpacity);
         this.settings.controllerButtonSize = Number(storage.controllerButtonSize);

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -159,6 +159,11 @@ if (!window.VSC.VideoSpeedConfig) {
         this.settings.exclusiveKeys = Boolean(storage.exclusiveKeys);
         this.settings.audioBoolean = Boolean(storage.audioBoolean);
         this.settings.startHidden = Boolean(storage.startHidden);
+        this.settings.liveCatchUpEnabled = Boolean(storage.liveCatchUpEnabled);
+        this.settings.liveCatchUpSpeed = Number(storage.liveCatchUpSpeed);
+        this.settings.liveCatchUpStartThreshold = Number(storage.liveCatchUpStartThreshold);
+        this.settings.liveCatchUpStopThreshold = Number(storage.liveCatchUpStopThreshold);
+        this.settings.liveResetSpeedAtEdge = Boolean(storage.liveResetSpeedAtEdge);
         this.settings.controllerOpacity = Number(storage.controllerOpacity);
         this.settings.controllerButtonSize = Number(storage.controllerButtonSize);
         // One-time migration: drop legacy controllerCSS key, reset to new model.

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -235,6 +235,7 @@ class VideoController {
       // Lifecycle restore, not a user choice — don't persist to lastSpeed.
       window.VSC.logger.info(`Media event ${event.type}: restoring speed to ${targetSpeed}`);
       this.actionHandler.adjustSpeed(event.target, targetSpeed, { source: 'init' });
+      this.actionHandler.updateLiveCatchUp(event.target);
     };
 
     // Bind event handlers
@@ -247,12 +248,17 @@ class VideoController {
       }
       mediaEventAction.call(this, event);
     };
+    this.handleLiveProgress = (event) => {
+      this.actionHandler.updateLiveCatchUp(event.target);
+    };
 
     // Add essential event listeners for speed restoration
     this.video.addEventListener('play', this.handlePlay);
     this.video.addEventListener('seeked', this.handleSeek);
+    this.video.addEventListener('timeupdate', this.handleLiveProgress);
+    this.video.addEventListener('progress', this.handleLiveProgress);
 
-    window.VSC.logger.debug('Added essential media event handlers: play, seeked');
+    window.VSC.logger.debug('Added essential media event handlers: play, seeked, timeupdate');
   }
 
   /**
@@ -299,6 +305,10 @@ class VideoController {
     }
     if (this.handleSeek) {
       this.video.removeEventListener('seeked', this.handleSeek);
+    }
+    if (this.handleLiveProgress) {
+      this.video.removeEventListener('timeupdate', this.handleLiveProgress);
+      this.video.removeEventListener('progress', this.handleLiveProgress);
     }
 
     // Disconnect mutation observer

--- a/src/core/video-controller.js
+++ b/src/core/video-controller.js
@@ -25,6 +25,10 @@ class VideoController {
     // Transient reset memory (not persisted, instance-specific)
     this.speedBeforeReset = null;
     this.positionBeforeJump = null;
+    this.liveCatchUpActive = false;
+    this.liveCatchUpPauseCandidate = null;
+    this.liveCatchUpResumeCandidate = null;
+    this.liveCatchUpSeekGeneration = 0;
 
     // Attach controller to video element first (needed for adjustSpeed)
     target.vsc = this;
@@ -229,36 +233,50 @@ class VideoController {
    * @private
    */
   setupEventHandlers() {
-    const mediaEventAction = (event) => {
+    const restoreSpeedForMediaEvent = (event) => {
       const targetSpeed = this.getTargetSpeed(event.target);
 
       // Lifecycle restore, not a user choice — don't persist to lastSpeed.
       window.VSC.logger.info(`Media event ${event.type}: restoring speed to ${targetSpeed}`);
       this.actionHandler.adjustSpeed(event.target, targetSpeed, { source: 'init' });
-      this.actionHandler.updateLiveCatchUp(event.target);
     };
 
     // Bind event handlers
-    this.handlePlay = mediaEventAction.bind(this);
+    this.handlePause = (event) => {
+      this.actionHandler.handleLivePause(event.target);
+    };
+    this.handlePlay = (event) => {
+      restoreSpeedForMediaEvent(event);
+      this.actionHandler.handleLivePlay(event.target);
+      this.actionHandler.updateLiveCatchUp(event.target);
+    };
+    this.handleSeeking = (event) => {
+      this.actionHandler.handleLiveSeek(event.target);
+    };
     // Don't restore speed on seeked if the video hasn't loaded data yet —
     // the player may still be initializing.
     this.handleSeek = (event) => {
       if (event.target.readyState < 2) {
         return;
       }
-      mediaEventAction.call(this, event);
+      restoreSpeedForMediaEvent(event);
+      this.actionHandler.updateLiveCatchUp(event.target);
     };
     this.handleLiveProgress = (event) => {
       this.actionHandler.updateLiveCatchUp(event.target);
     };
 
     // Add essential event listeners for speed restoration
+    this.video.addEventListener('pause', this.handlePause);
     this.video.addEventListener('play', this.handlePlay);
+    this.video.addEventListener('seeking', this.handleSeeking);
     this.video.addEventListener('seeked', this.handleSeek);
     this.video.addEventListener('timeupdate', this.handleLiveProgress);
     this.video.addEventListener('progress', this.handleLiveProgress);
 
-    window.VSC.logger.debug('Added essential media event handlers: play, seeked, timeupdate');
+    window.VSC.logger.debug(
+      'Added essential media event handlers: pause, play, seeking, seeked, timeupdate'
+    );
   }
 
   /**
@@ -300,8 +318,14 @@ class VideoController {
     }
 
     // Remove event listeners
+    if (this.handlePause) {
+      this.video.removeEventListener('pause', this.handlePause);
+    }
     if (this.handlePlay) {
       this.video.removeEventListener('play', this.handlePlay);
+    }
+    if (this.handleSeeking) {
+      this.video.removeEventListener('seeking', this.handleSeeking);
     }
     if (this.handleSeek) {
       this.video.removeEventListener('seeked', this.handleSeek);

--- a/src/site-handlers/base-handler.js
+++ b/src/site-handlers/base-handler.js
@@ -61,6 +61,16 @@ class BaseSiteHandler {
   }
 
   /**
+   * Get site-specific live latency when the native media timeline is unreliable.
+   * Return null when the site has no better live-edge signal.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {number|null} Seconds behind live edge
+   */
+  getLiveLatency(_video) {
+    return null;
+  }
+
+  /**
    * Handle site-specific initialization
    * @param {Document} document - Document object
    */

--- a/src/site-handlers/index.js
+++ b/src/site-handlers/index.js
@@ -88,6 +88,16 @@ class SiteHandlerManager {
   }
 
   /**
+   * Get site-specific live latency when available.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {number|null} Seconds behind live edge
+   */
+  getLiveLatency(video) {
+    const handler = this.getCurrentHandler();
+    return handler.getLiveLatency(video);
+  }
+
+  /**
    * Check if a video should be ignored
    * @param {HTMLMediaElement} video - Video element
    * @returns {boolean} True if video should be ignored

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -66,6 +66,40 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
   }
 
   /**
+   * YouTube live streams expose the reliable live edge through their player
+   * progress state. The native HTMLMediaElement seekable range can point at
+   * the full manifest timeline and overstate latency by hours.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {number|null} Seconds behind live edge
+   */
+  getLiveLatency(video) {
+    const player = video.ownerDocument.getElementById('movie_player');
+    if (!player || typeof player.getProgressState !== 'function') {
+      return null;
+    }
+
+    const progressState = player.getProgressState();
+    const videoData =
+      typeof player.getVideoData === 'function' ? player.getVideoData() : { isLive: false };
+
+    if (!videoData?.isLive) {
+      return null;
+    }
+
+    if (progressState?.isAtLiveHead) {
+      return 0;
+    }
+
+    const current = Number(progressState?.current ?? video.currentTime);
+    const liveEdge = Number(progressState?.seekableEnd);
+    if (!Number.isFinite(current) || !Number.isFinite(liveEdge)) {
+      return null;
+    }
+
+    return Math.max(0, liveEdge - current);
+  }
+
+  /**
    * Get YouTube-specific video container selectors
    * @returns {Array<string>} CSS selectors
    */

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -68,7 +68,8 @@
           <label for="liveCatchUpEnabled"
             >Catch up to live<br />
             <em
-              >On live streams, speed up automatically until playback reaches the live edge.</em
+              >After pausing near live, speed up automatically until playback reaches the live
+              edge.</em
             ></label
           >
           <input id="liveCatchUpEnabled" type="checkbox" />

--- a/src/ui/options/options.html
+++ b/src/ui/options/options.html
@@ -64,6 +64,43 @@
           >
           <input id="exclusiveKeys" type="checkbox" />
         </div>
+        <div class="row">
+          <label for="liveCatchUpEnabled"
+            >Catch up to live<br />
+            <em
+              >On live streams, speed up automatically until playback reaches the live edge.</em
+            ></label
+          >
+          <input id="liveCatchUpEnabled" type="checkbox" />
+        </div>
+        <div class="row">
+          <label for="liveCatchUpSpeed"
+            >Live catch-up speed<br />
+            <em>Playback speed used while catching up. Default: 1.5</em></label
+          >
+          <input id="liveCatchUpSpeed" type="text" />
+        </div>
+        <div class="row">
+          <label for="liveCatchUpStartThreshold"
+            >Live catch-up start<br />
+            <em>Seconds behind live before catch-up starts. Default: 10</em></label
+          >
+          <input id="liveCatchUpStartThreshold" type="text" />
+        </div>
+        <div class="row">
+          <label for="liveCatchUpStopThreshold"
+            >Live edge threshold<br />
+            <em>Seconds from live where speed returns to 1x. Default: 3</em></label
+          >
+          <input id="liveCatchUpStopThreshold" type="text" />
+        </div>
+        <div class="row">
+          <label for="liveResetSpeedAtEdge"
+            >Reset speed at live edge<br />
+            <em>On live streams, return manual speeds above 1x to 1x near the live edge.</em></label
+          >
+          <input id="liveResetSpeedAtEdge" type="checkbox" />
+        </div>
       </section>
     </div>
 

--- a/src/ui/options/options.js
+++ b/src/ui/options/options.js
@@ -654,6 +654,16 @@ function validate() {
   }
 
   const regEndsWithFlags = window.VSC.Constants.regEndsWithFlags;
+  const showValidationError = (message) => {
+    status.textContent = message;
+    status.classList.add('show', 'error');
+    valid = false;
+    window.validationTimeout = setTimeout(() => {
+      status.textContent = '';
+      status.classList.remove('show', 'error');
+    }, 5000);
+    return valid;
+  };
 
   // Validate site rules
   const rules = collectSiteRules();
@@ -673,14 +683,9 @@ function validate() {
         }
         new RegExp(regex, flags);
       } catch {
-        status.textContent = `Error: Invalid site rule regex: "${rule.pattern}". Unable to save.`;
-        status.classList.add('show', 'error');
-        valid = false;
-        window.validationTimeout = setTimeout(() => {
-          status.textContent = '';
-          status.classList.remove('show', 'error');
-        }, 5000);
-        return valid;
+        return showValidationError(
+          `Error: Invalid site rule regex: "${rule.pattern}". Unable to save.`
+        );
       }
     }
 
@@ -690,18 +695,45 @@ function validate() {
         rule.speed < window.VSC.Constants.SPEED_LIMITS.MIN ||
         rule.speed > window.VSC.Constants.SPEED_LIMITS.MAX
       ) {
-        status.textContent = `Error: Speed for "${rule.pattern}" must be between ${
-          window.VSC.Constants.SPEED_LIMITS.MIN
-        } and ${window.VSC.Constants.SPEED_LIMITS.MAX}.`;
-        status.classList.add('show', 'error');
-        valid = false;
-        window.validationTimeout = setTimeout(() => {
-          status.textContent = '';
-          status.classList.remove('show', 'error');
-        }, 5000);
-        return valid;
+        return showValidationError(
+          `Error: Speed for "${rule.pattern}" must be between ${
+            window.VSC.Constants.SPEED_LIMITS.MIN
+          } and ${window.VSC.Constants.SPEED_LIMITS.MAX}.`
+        );
       }
     }
+  }
+
+  const liveCatchUpSpeed = Number(document.getElementById('liveCatchUpSpeed').value);
+  const liveCatchUpStartThreshold = Number(
+    document.getElementById('liveCatchUpStartThreshold').value
+  );
+  const liveCatchUpStopThreshold = Number(
+    document.getElementById('liveCatchUpStopThreshold').value
+  );
+
+  if (
+    !Number.isFinite(liveCatchUpSpeed) ||
+    liveCatchUpSpeed < window.VSC.Constants.SPEED_LIMITS.MIN ||
+    liveCatchUpSpeed > window.VSC.Constants.SPEED_LIMITS.MAX
+  ) {
+    return showValidationError(
+      `Error: Live catch-up speed must be between ${window.VSC.Constants.SPEED_LIMITS.MIN} and ${window.VSC.Constants.SPEED_LIMITS.MAX}.`
+    );
+  }
+
+  if (!Number.isFinite(liveCatchUpStartThreshold) || liveCatchUpStartThreshold < 0) {
+    return showValidationError('Error: Live catch-up start must be 0 seconds or greater.');
+  }
+
+  if (!Number.isFinite(liveCatchUpStopThreshold) || liveCatchUpStopThreshold < 0) {
+    return showValidationError('Error: Live edge threshold must be 0 seconds or greater.');
+  }
+
+  if (liveCatchUpStopThreshold > liveCatchUpStartThreshold) {
+    return showValidationError(
+      'Error: Live edge threshold must be less than or equal to the catch-up start.'
+    );
   }
 
   return valid;
@@ -725,6 +757,15 @@ async function save_options() {
     const exclusiveKeys = document.getElementById('exclusiveKeys').checked;
     const audioBoolean = document.getElementById('audioBoolean').checked;
     const startHidden = document.getElementById('startHidden').checked;
+    const liveCatchUpEnabled = document.getElementById('liveCatchUpEnabled').checked;
+    const liveCatchUpSpeed = Number(document.getElementById('liveCatchUpSpeed').value);
+    const liveCatchUpStartThreshold = Number(
+      document.getElementById('liveCatchUpStartThreshold').value
+    );
+    const liveCatchUpStopThreshold = Number(
+      document.getElementById('liveCatchUpStopThreshold').value
+    );
+    const liveResetSpeedAtEdge = document.getElementById('liveResetSpeedAtEdge').checked;
     const controllerOpacity = Number(document.getElementById('controllerOpacity').value);
     const controllerButtonSize = Number(document.getElementById('controllerButtonSize').value);
     const logLevel = parseInt(document.getElementById('logLevel').value);
@@ -765,6 +806,11 @@ async function save_options() {
       exclusiveKeys: exclusiveKeys,
       audioBoolean: audioBoolean,
       startHidden: startHidden,
+      liveCatchUpEnabled: liveCatchUpEnabled,
+      liveCatchUpSpeed: liveCatchUpSpeed,
+      liveCatchUpStartThreshold: liveCatchUpStartThreshold,
+      liveCatchUpStopThreshold: liveCatchUpStopThreshold,
+      liveResetSpeedAtEdge: liveResetSpeedAtEdge,
       controllerOpacity: controllerOpacity,
       controllerButtonSize: controllerButtonSize,
       logLevel: logLevel,
@@ -811,6 +857,11 @@ async function restore_options() {
     document.getElementById('exclusiveKeys').checked = storage.exclusiveKeys;
     document.getElementById('audioBoolean').checked = storage.audioBoolean;
     document.getElementById('startHidden').checked = storage.startHidden;
+    document.getElementById('liveCatchUpEnabled').checked = storage.liveCatchUpEnabled;
+    document.getElementById('liveCatchUpSpeed').value = storage.liveCatchUpSpeed;
+    document.getElementById('liveCatchUpStartThreshold').value = storage.liveCatchUpStartThreshold;
+    document.getElementById('liveCatchUpStopThreshold').value = storage.liveCatchUpStopThreshold;
+    document.getElementById('liveResetSpeedAtEdge').checked = storage.liveResetSpeedAtEdge;
     document.getElementById('controllerOpacity').value = storage.controllerOpacity;
     document.getElementById('controllerButtonSize').value = storage.controllerButtonSize;
     document.getElementById('logLevel').value = storage.logLevel;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -41,6 +41,7 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     liveCatchUpSpeed: 1.5, // speed used while catching up to a live edge
     liveCatchUpStartThreshold: 10, // seconds behind live before catch-up starts
     liveCatchUpStopThreshold: 3, // seconds behind live considered close enough
+    liveCatchUpPauseNearLiveThreshold: 900, // pause must begin within 15 minutes of live
     liveResetSpeedAtEdge: false, // reset manual >1x speed at the live edge
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -37,6 +37,11 @@ if (!window.VSC.Constants.DEFAULT_SETTINGS) {
     exclusiveKeys: false, // default: false
     audioBoolean: true, // default: true (enable audio controller support)
     startHidden: false, // default: false
+    liveCatchUpEnabled: false, // default: false
+    liveCatchUpSpeed: 1.5, // speed used while catching up to a live edge
+    liveCatchUpStartThreshold: 10, // seconds behind live before catch-up starts
+    liveCatchUpStopThreshold: 3, // seconds behind live considered close enough
+    liveResetSpeedAtEdge: false, // reset manual >1x speed at the live edge
     controllerOpacity: 0.3, // default: 0.3
     controllerButtonSize: 14,
     customCSS: '', // user's additional CSS injected alongside the built-in defaults

--- a/src/utils/event-manager.js
+++ b/src/utils/event-manager.js
@@ -10,6 +10,7 @@ class EventManager {
     this.actionHandler = actionHandler;
     this.listeners = new Map();
     this.coolDown = false;
+    this.coolDownExpectedSpeed = null;
 
     // Event deduplication to prevent duplicate key processing
     this.lastKeyEventSignature = null;
@@ -23,6 +24,26 @@ class EventManager {
     // USER_GESTURE_WINDOW_MS of this is treated as intentional and accepted
     // immediately rather than fought — handles native site speed controls.
     this.lastUserInteractionAt = 0;
+  }
+
+  /**
+   * Get the speed value that should be protected from automatic site resets.
+   * @param {HTMLMediaElement} video - Video element
+   * @returns {number|null} Authoritative speed, or null when no value should be protected
+   * @private
+   */
+  getAuthoritativeSpeed(video) {
+    if (Number.isFinite(this.coolDownExpectedSpeed)) {
+      return this.coolDownExpectedSpeed;
+    }
+
+    if (video?.vsc?.liveCatchUpActive && this.config.settings.liveCatchUpEnabled) {
+      const catchUpSpeed = Number(this.config.settings.liveCatchUpSpeed);
+      return Number.isFinite(catchUpSpeed) ? catchUpSpeed : null;
+    }
+
+    const lastSpeed = Number(this.config.settings.lastSpeed);
+    return Number.isFinite(lastSpeed) ? lastSpeed : null;
   }
 
   /**
@@ -274,8 +295,8 @@ class EventManager {
       }
 
       // RESTORE our authoritative value since external change already happened
-      if (video.vsc && this.config.settings.lastSpeed !== null) {
-        const authoritativeSpeed = this.config.settings.lastSpeed;
+      const authoritativeSpeed = this.getAuthoritativeSpeed(video);
+      if (video.vsc && authoritativeSpeed !== null) {
         if (Math.abs(video.playbackRate - authoritativeSpeed) > 0.01) {
           window.VSC.logger.info(
             `Restoring speed during cooldown from external ${video.playbackRate} to authoritative ${authoritativeSpeed}`
@@ -326,9 +347,9 @@ class EventManager {
     // to fight back or accept. User-initiated changes (detected via gesture window)
     // are accepted immediately — this allows native site controls (e.g. YouTube's
     // speed menu or < > shortcuts) to coexist with our fight-back logic.
-    const authoritativeSpeed = this.config.settings.lastSpeed;
+    const authoritativeSpeed = this.getAuthoritativeSpeed(video);
 
-    if (authoritativeSpeed && Math.abs(video.playbackRate - authoritativeSpeed) > 0.01) {
+    if (authoritativeSpeed !== null && Math.abs(video.playbackRate - authoritativeSpeed) > 0.01) {
       const timeSinceGesture = event.timeStamp - this.lastUserInteractionAt;
       const isUserGesture = timeSinceGesture < EventManager.USER_GESTURE_WINDOW_MS;
 
@@ -378,7 +399,7 @@ class EventManager {
           `Fight detection: attempt ${this.fightCount}/${EventManager.MAX_FIGHT_COUNT}, re-applying ${authoritativeSpeed} (cooldown ${cooldown}ms)`
         );
         window.VSC.siteHandlerManager.handleSpeedChange(video, authoritativeSpeed);
-        this.refreshCoolDown(cooldown);
+        this.refreshCoolDown(cooldown, authoritativeSpeed);
         event.stopImmediatePropagation();
         return;
       }
@@ -394,15 +415,17 @@ class EventManager {
   /**
    * Start cooldown period to prevent event spam
    */
-  refreshCoolDown(duration = EventManager.BASE_COOLDOWN_MS) {
+  refreshCoolDown(duration = EventManager.BASE_COOLDOWN_MS, expectedSpeed = null) {
     window.VSC.logger.debug(`Begin refreshCoolDown (${duration}ms)`);
 
     if (this.coolDown) {
       clearTimeout(this.coolDown);
     }
 
+    this.coolDownExpectedSpeed = Number.isFinite(expectedSpeed) ? expectedSpeed : null;
     this.coolDown = setTimeout(() => {
       this.coolDown = false;
+      this.coolDownExpectedSpeed = null;
     }, duration);
 
     window.VSC.logger.debug('End refreshCoolDown');
@@ -428,6 +451,7 @@ class EventManager {
       clearTimeout(this.coolDown);
       this.coolDown = false;
     }
+    this.coolDownExpectedSpeed = null;
 
     if (this.fightTimer) {
       clearTimeout(this.fightTimer);

--- a/tests/helpers/test-utils.js
+++ b/tests/helpers/test-utils.js
@@ -53,6 +53,15 @@ export function createMockVideo(options = {}) {
       writable: true,
       configurable: true,
     },
+    seekable: {
+      value: options.seekable || {
+        length: 0,
+        start: () => 0,
+        end: () => 0,
+      },
+      writable: true,
+      configurable: true,
+    },
     ownerDocument: {
       value: document,
       writable: true,

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -269,6 +269,71 @@ describe('ActionHandler', () => {
     expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
   });
 
+  it('ActionHandler should not pin catch-up speed after the initial live catch-up suggestion', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+    config.settings.liveCatchUpStartThreshold = 10;
+    config.settings.liveCatchUpStopThreshold = 3;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 100,
+      },
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(1.5);
+
+    mockVideo.playbackRate = 1.0;
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(1.0);
+
+    mockVideo.playbackRate = 2.0;
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(2.0);
+  });
+
+  it('ActionHandler should reset the catch-up cycle at live edge without forcing slow speeds to 1x', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+    config.settings.liveCatchUpStartThreshold = 10;
+    config.settings.liveCatchUpStopThreshold = 3;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 100,
+      },
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
+
+    mockVideo.currentTime = 98;
+    mockVideo.playbackRate = 0.75;
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(0.75);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+
+    mockVideo.currentTime = 80;
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(1.5);
+  });
+
   it('ActionHandler should reset manual speed at the live edge when configured', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -57,6 +57,30 @@ describe('ActionHandler', () => {
     return mockVideo;
   }
 
+  function configureLiveCatchUp(config, overrides = {}) {
+    Object.assign(config.settings, {
+      liveCatchUpEnabled: true,
+      liveCatchUpSpeed: 1.5,
+      liveCatchUpStartThreshold: 10,
+      liveCatchUpStopThreshold: 3,
+      liveCatchUpPauseNearLiveThreshold: 900,
+      ...overrides,
+    });
+  }
+
+  function createLiveSeekable(start = 0, end = 100) {
+    return {
+      length: 1,
+      start: () => start,
+      end: () => end,
+    };
+  }
+
+  function armLiveCatchUpFromPause(actionHandler, video) {
+    actionHandler.handleLivePause(video);
+    actionHandler.handleLivePlay(video);
+  }
+
   afterEach(() => {
     cleanupChromeMock();
     if (mockDOM) {
@@ -187,27 +211,20 @@ describe('ActionHandler', () => {
   it('ActionHandler should catch up to live and restore 1x at the live edge', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
-    config.settings.liveCatchUpEnabled = true;
-    config.settings.liveCatchUpSpeed = 1.5;
-    config.settings.liveCatchUpStartThreshold = 10;
-    config.settings.liveCatchUpStopThreshold = 3;
+    configureLiveCatchUp(config);
     config.settings.rememberSpeed = true;
     config.settings.lastSpeed = 1.0;
 
     const eventManager = new window.VSC.EventManager(config, null);
     const actionHandler = new window.VSC.ActionHandler(config, eventManager);
-    const seekable = {
-      length: 1,
-      start: () => 0,
-      end: () => 100,
-    };
 
     const mockVideo = createTestVideoWithController(config, actionHandler, {
       currentTime: 80,
       duration: Infinity,
-      seekable,
+      seekable: createLiveSeekable(),
     });
 
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
     expect(mockVideo.playbackRate).toBe(1.5);
     expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
@@ -218,76 +235,145 @@ describe('ActionHandler', () => {
 
     expect(mockVideo.playbackRate).toBe(1.0);
     expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(mockVideo.vsc.liveCatchUpResumeCandidate).toBeNull();
     expect(config.settings.lastSpeed).toBe(1.0);
   });
 
   it('ActionHandler should not treat regular videos as live catch-up candidates', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
-    config.settings.liveCatchUpEnabled = true;
-    config.settings.liveCatchUpSpeed = 1.5;
+    configureLiveCatchUp(config);
 
     const actionHandler = new window.VSC.ActionHandler(config, null);
     const mockVideo = createTestVideoWithController(config, actionHandler, {
       currentTime: 20,
       duration: 100,
-      seekable: {
-        length: 1,
-        start: () => 0,
-        end: () => 100,
-      },
+      seekable: createLiveSeekable(),
     });
 
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
 
     expect(mockVideo.playbackRate).toBe(1.0);
-    expect(mockVideo.vsc.liveCatchUpActive).toBeUndefined();
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
   });
 
   it('ActionHandler should catch up finite-duration live streams with a sliding seekable window', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
-    config.settings.liveCatchUpEnabled = true;
-    config.settings.liveCatchUpSpeed = 1.5;
-    config.settings.liveCatchUpStartThreshold = 10;
-    config.settings.liveCatchUpStopThreshold = 3;
+    configureLiveCatchUp(config);
 
     const actionHandler = new window.VSC.ActionHandler(config, null);
     const mockVideo = createTestVideoWithController(config, actionHandler, {
       currentTime: 80,
       duration: 100,
-      seekable: {
-        length: 1,
-        start: () => 30,
-        end: () => 100,
-      },
+      seekable: createLiveSeekable(30, 100),
     });
 
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
 
     expect(mockVideo.playbackRate).toBe(1.5);
     expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
   });
 
-  it('ActionHandler should not pin catch-up speed after the initial live catch-up suggestion', async () => {
+  it('ActionHandler should not catch up after seeking behind live without a pause-resume intent', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
-    config.settings.liveCatchUpEnabled = true;
-    config.settings.liveCatchUpSpeed = 1.5;
-    config.settings.liveCatchUpStartThreshold = 10;
-    config.settings.liveCatchUpStopThreshold = 3;
+    configureLiveCatchUp(config);
 
     const actionHandler = new window.VSC.ActionHandler(config, null);
     const mockVideo = createTestVideoWithController(config, actionHandler, {
       currentTime: 80,
       duration: Infinity,
-      seekable: {
-        length: 1,
-        start: () => 0,
-        end: () => 100,
-      },
+      seekable: createLiveSeekable(),
     });
 
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+  });
+
+  it('ActionHandler should not arm catch-up when pause starts too far from live', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 0,
+      duration: Infinity,
+      seekable: createLiveSeekable(0, 1000),
+    });
+
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(mockVideo.vsc.liveCatchUpResumeCandidate).toBeNull();
+  });
+
+  it('ActionHandler should invalidate a near-live pause candidate when the user seeks', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+
+    actionHandler.handleLivePause(mockVideo);
+    expect(mockVideo.vsc.liveCatchUpPauseCandidate).not.toBeNull();
+
+    actionHandler.handleLiveSeek(mockVideo);
+    actionHandler.handleLivePlay(mockVideo);
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(mockVideo.vsc.liveCatchUpPauseCandidate).toBeNull();
+    expect(mockVideo.vsc.liveCatchUpResumeCandidate).toBeNull();
+  });
+
+  it('ActionHandler should expire a stale pause-resume catch-up window', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
+    mockVideo.vsc.liveCatchUpResumeCandidate.resumedAt = Date.now() - 31000;
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(mockVideo.vsc.liveCatchUpResumeCandidate).toBeNull();
+  });
+
+  it('ActionHandler should not pin catch-up speed after the initial live catch-up suggestion', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
     expect(mockVideo.playbackRate).toBe(1.5);
 
@@ -300,25 +386,43 @@ describe('ActionHandler', () => {
     expect(mockVideo.playbackRate).toBe(2.0);
   });
 
-  it('ActionHandler should reset the catch-up cycle at live edge without forcing slow speeds to 1x', async () => {
+  it('ActionHandler should let manual speed changes take over during live catch-up', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
-    config.settings.liveCatchUpEnabled = true;
-    config.settings.liveCatchUpSpeed = 1.5;
-    config.settings.liveCatchUpStartThreshold = 10;
-    config.settings.liveCatchUpStopThreshold = 3;
+    configureLiveCatchUp(config);
 
     const actionHandler = new window.VSC.ActionHandler(config, null);
     const mockVideo = createTestVideoWithController(config, actionHandler, {
       currentTime: 80,
       duration: Infinity,
-      seekable: {
-        length: 1,
-        start: () => 0,
-        end: () => 100,
-      },
+      seekable: createLiveSeekable(),
     });
 
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(1.5);
+
+    actionHandler.adjustSpeed(mockVideo, 2.0);
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(2.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(mockVideo.vsc.liveCatchUpResumeCandidate).toBeNull();
+  });
+
+  it('ActionHandler should reset the catch-up cycle at live edge without forcing slow speeds to 1x', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
     expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
 
@@ -330,6 +434,10 @@ describe('ActionHandler', () => {
     expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
 
     mockVideo.currentTime = 80;
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(0.75);
+
+    armLiveCatchUpFromPause(actionHandler, mockVideo);
     actionHandler.updateLiveCatchUp(mockVideo);
     expect(mockVideo.playbackRate).toBe(1.5);
   });

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -244,6 +244,31 @@ describe('ActionHandler', () => {
     expect(mockVideo.vsc.liveCatchUpActive).toBeUndefined();
   });
 
+  it('ActionHandler should catch up finite-duration live streams with a sliding seekable window', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+    config.settings.liveCatchUpStartThreshold = 10;
+    config.settings.liveCatchUpStopThreshold = 3;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: 100,
+      seekable: {
+        length: 1,
+        start: () => 30,
+        end: () => 100,
+      },
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.5);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
+  });
+
   it('ActionHandler should reset manual speed at the live edge when configured', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();

--- a/tests/unit/core/action-handler.test.js
+++ b/tests/unit/core/action-handler.test.js
@@ -184,6 +184,90 @@ describe('ActionHandler', () => {
     expect(mockVideo.currentTime).toBe(55);
   });
 
+  it('ActionHandler should catch up to live and restore 1x at the live edge', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+    config.settings.liveCatchUpStartThreshold = 10;
+    config.settings.liveCatchUpStopThreshold = 3;
+    config.settings.rememberSpeed = true;
+    config.settings.lastSpeed = 1.0;
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+    const seekable = {
+      length: 1,
+      start: () => 0,
+      end: () => 100,
+    };
+
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 80,
+      duration: Infinity,
+      seekable,
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+    expect(mockVideo.playbackRate).toBe(1.5);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(true);
+    expect(config.settings.lastSpeed).toBe(1.0);
+
+    mockVideo.currentTime = 98;
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBe(false);
+    expect(config.settings.lastSpeed).toBe(1.0);
+  });
+
+  it('ActionHandler should not treat regular videos as live catch-up candidates', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      currentTime: 20,
+      duration: 100,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 100,
+      },
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(mockVideo.vsc.liveCatchUpActive).toBeUndefined();
+  });
+
+  it('ActionHandler should reset manual speed at the live edge when configured', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.liveCatchUpEnabled = false;
+    config.settings.liveResetSpeedAtEdge = true;
+    config.settings.liveCatchUpStopThreshold = 3;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const mockVideo = createTestVideoWithController(config, actionHandler, {
+      playbackRate: 1.75,
+      currentTime: 98,
+      duration: Infinity,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 100,
+      },
+    });
+
+    actionHandler.updateLiveCatchUp(mockVideo);
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+  });
+
   it('ActionHandler should handle mark and jump actions', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();

--- a/tests/unit/core/settings.test.js
+++ b/tests/unit/core/settings.test.js
@@ -32,6 +32,7 @@ describe('Settings', () => {
     expect(config.settings.enabled).toBe(true);
     expect(config.settings.lastSpeed).toBe(1.0);
     expect(config.settings.logLevel).toBe(3);
+    expect(config.settings.liveCatchUpPauseNearLiveThreshold).toBe(900);
   });
 
   it('VideoSpeedConfig should load settings from storage', async () => {
@@ -41,6 +42,7 @@ describe('Settings', () => {
     expect(settings).toBeDefined();
     expect(settings.enabled).toBe(true);
     expect(settings.lastSpeed).toBeNull(); // no user choice yet
+    expect(settings.liveCatchUpPauseNearLiveThreshold).toBe(900);
   });
 
   it('VideoSpeedConfig should save settings to storage', async () => {

--- a/tests/unit/core/video-controller.test.js
+++ b/tests/unit/core/video-controller.test.js
@@ -47,6 +47,25 @@ describe('VideoController', () => {
     }
   });
 
+  function configureLiveCatchUp(config, overrides = {}) {
+    Object.assign(config.settings, {
+      liveCatchUpEnabled: true,
+      liveCatchUpSpeed: 1.5,
+      liveCatchUpStartThreshold: 10,
+      liveCatchUpStopThreshold: 3,
+      liveCatchUpPauseNearLiveThreshold: 900,
+      ...overrides,
+    });
+  }
+
+  function createLiveSeekable(start = 0, end = 100) {
+    return {
+      length: 1,
+      start: () => start,
+      end: () => end,
+    };
+  }
+
   it('VideoController should initialize with video element', async () => {
     const config = window.VSC.videoSpeedConfig;
     await config.load();
@@ -302,6 +321,9 @@ describe('VideoController', () => {
 
     // Should have added media event listeners
     expect(addedListeners.length > 0).toBe(true); // Should have added some listeners
+    expect(addedListeners.map(({ type }) => type)).toEqual(
+      expect.arrayContaining(['pause', 'play', 'seeking', 'seeked', 'timeupdate', 'progress'])
+    );
 
     // Should have proper vsc structure with speedIndicator
     expect(mockVideo.vsc).toBeDefined();
@@ -366,5 +388,92 @@ describe('VideoController', () => {
     // Lifecycle restore should re-apply speed but NOT corrupt lastSpeed
     expect(mockVideo.playbackRate).toBe(1.8);
     expect(config.settings.lastSpeed).toBe(1.8);
+  });
+
+  it('pause/play events should arm live catch-up after pausing near live', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+    mockDOM.container.appendChild(mockVideo);
+
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    mockVideo.paused = true;
+    mockVideo.dispatchEvent({ type: 'pause' });
+    expect(controller.liveCatchUpPauseCandidate).not.toBeNull();
+
+    mockVideo.paused = false;
+    mockVideo.dispatchEvent({ type: 'play' });
+
+    expect(mockVideo.playbackRate).toBe(1.5);
+    expect(controller.liveCatchUpActive).toBe(true);
+  });
+
+  it('pause/play events should not arm live catch-up when pause starts too far behind live', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({
+      currentTime: 0,
+      duration: Infinity,
+      seekable: createLiveSeekable(0, 1000),
+    });
+    mockDOM.container.appendChild(mockVideo);
+
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    mockVideo.paused = true;
+    mockVideo.dispatchEvent({ type: 'pause' });
+    mockVideo.paused = false;
+    mockVideo.dispatchEvent({ type: 'play' });
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(controller.liveCatchUpActive).toBe(false);
+    expect(controller.liveCatchUpPauseCandidate).toBeNull();
+    expect(controller.liveCatchUpResumeCandidate).toBeNull();
+  });
+
+  it('seeking event should invalidate a pending live catch-up pause intent', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    configureLiveCatchUp(config);
+
+    const eventManager = new window.VSC.EventManager(config, null);
+    const actionHandler = new window.VSC.ActionHandler(config, eventManager);
+
+    const mockVideo = createMockVideo({
+      currentTime: 80,
+      duration: Infinity,
+      seekable: createLiveSeekable(),
+    });
+    mockDOM.container.appendChild(mockVideo);
+
+    const controller = new window.VSC.VideoController(mockVideo, null, config, actionHandler);
+
+    mockVideo.paused = true;
+    mockVideo.dispatchEvent({ type: 'pause' });
+    expect(controller.liveCatchUpPauseCandidate).not.toBeNull();
+
+    mockVideo.dispatchEvent({ type: 'seeking' });
+    mockVideo.paused = false;
+    mockVideo.dispatchEvent({ type: 'play' });
+
+    expect(mockVideo.playbackRate).toBe(1.0);
+    expect(controller.liveCatchUpActive).toBe(false);
+    expect(controller.liveCatchUpPauseCandidate).toBeNull();
+    expect(controller.liveCatchUpResumeCandidate).toBeNull();
   });
 });

--- a/tests/unit/site-handlers/youtube-handler.test.js
+++ b/tests/unit/site-handlers/youtube-handler.test.js
@@ -8,6 +8,7 @@ import {
   cleanupChromeMock,
   resetMockStorage,
 } from '../../helpers/chrome-mock.js';
+import { createMockVideo } from '../../helpers/test-utils.js';
 
 describe('YouTubeHandler', () => {
   beforeEach(() => {
@@ -81,5 +82,57 @@ describe('YouTubeHandler', () => {
     expect(result.insertionPoint).toBe(parent);
 
     grandparent.remove();
+  });
+
+  it('returns zero live latency when YouTube reports playback is at live head', () => {
+    const handler = new window.VSC.YouTubeHandler();
+    const video = createMockVideo({
+      currentTime: 11355,
+      duration: 14610,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 14610,
+      },
+    });
+    const player = document.createElement('div');
+    player.id = 'movie_player';
+    player.getVideoData = () => ({ isLive: true });
+    player.getProgressState = () => ({
+      current: 11355,
+      seekableEnd: 11355,
+      isAtLiveHead: true,
+    });
+    document.body.appendChild(player);
+
+    expect(handler.getLiveLatency(video)).toBe(0);
+
+    player.remove();
+  });
+
+  it('uses YouTube progress state instead of native seekable end for live latency', () => {
+    const handler = new window.VSC.YouTubeHandler();
+    const video = createMockVideo({
+      currentTime: 11355,
+      duration: 14610,
+      seekable: {
+        length: 1,
+        start: () => 0,
+        end: () => 14610,
+      },
+    });
+    const player = document.createElement('div');
+    player.id = 'movie_player';
+    player.getVideoData = () => ({ isLive: true });
+    player.getProgressState = () => ({
+      current: 11355,
+      seekableEnd: 11435,
+      isAtLiveHead: false,
+    });
+    document.body.appendChild(player);
+
+    expect(handler.getLiveLatency(video)).toBe(80);
+
+    player.remove();
   });
 });

--- a/tests/unit/utils/event-manager.test.js
+++ b/tests/unit/utils/event-manager.test.js
@@ -183,6 +183,46 @@ describe('EventManager', () => {
     expect(externalAdjustCalled).toBe(false);
   });
 
+  it('live catch-up setSpeed should not restore stale lastSpeed during cooldown', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.lastSpeed = 1.0;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const eventManager = new window.VSC.EventManager(config, actionHandler);
+    actionHandler.eventManager = eventManager;
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockVideo.vsc = {
+      div: document.createElement('div'),
+      speedIndicator: { textContent: '1.00' },
+    };
+    Object.defineProperty(mockVideo, 'readyState', { value: 4, configurable: true });
+
+    let currentRate = 1.0;
+    Object.defineProperty(mockVideo, 'playbackRate', {
+      get() {
+        return currentRate;
+      },
+      set(value) {
+        currentRate = value;
+        eventManager.handleRateChange({
+          composedPath: () => [mockVideo],
+          target: mockVideo,
+          detail: null,
+          stopImmediatePropagation: () => {},
+        });
+      },
+      configurable: true,
+    });
+
+    actionHandler.setSpeed(mockVideo, 1.5, 'liveCatchUp');
+
+    expect(mockVideo.playbackRate).toBe(1.5);
+    expect(mockVideo.vsc.speedIndicator.textContent).toBe('1.50');
+    expect(config.settings.lastSpeed).toBe(1.0);
+  });
+
   // Fight back / extension event tests
 
   it('should restore authoritative speed on external ratechange', async () => {
@@ -210,6 +250,39 @@ describe('EventManager', () => {
     eventManager.handleRateChange(mockEvent);
 
     expect(mockVideo.playbackRate).toBe(1.5);
+    expect(eventStopped).toBe(true);
+  });
+
+  it('should use live catch-up speed as authoritative while catch-up is active', async () => {
+    const config = window.VSC.videoSpeedConfig;
+    await config.load();
+    config.settings.lastSpeed = 1.0;
+    config.settings.liveCatchUpEnabled = true;
+    config.settings.liveCatchUpSpeed = 1.5;
+
+    const actionHandler = new window.VSC.ActionHandler(config, null);
+    const eventManager = new window.VSC.EventManager(config, actionHandler);
+
+    const mockVideo = createMockVideo({ playbackRate: 1.0 });
+    mockVideo.vsc = {
+      speedIndicator: { textContent: '1.50' },
+      liveCatchUpActive: true,
+    };
+    Object.defineProperty(mockVideo, 'readyState', { value: 4, configurable: true });
+
+    let eventStopped = false;
+    eventManager.handleRateChange({
+      composedPath: () => [mockVideo],
+      target: mockVideo,
+      detail: null,
+      timeStamp: 1000,
+      stopImmediatePropagation: () => {
+        eventStopped = true;
+      },
+    });
+
+    expect(mockVideo.playbackRate).toBe(1.5);
+    expect(config.settings.lastSpeed).toBe(1.0);
     expect(eventStopped).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

This PR adds live-edge aware behavior for live streams. It contains two related, but distinct, opt-in behaviors:

1. **Live stream catch-up after pause/resume**
   - If the viewer pauses near the live edge and later resumes behind live, the extension can temporarily increase playback speed until the stream catches up.
   - Once catch-up reaches the configured live-edge threshold, the temporary speed is cleared and playback returns to `1x`.

2. **Optional reset to `1x` at the live edge**
   - Live streams often become awkward when playback remains above `1x` after reaching the live edge, because there is no buffered future content to consume.
   - This PR adds an optional setting that resets manual speeds above `1x` back to `1x` when the stream reaches the live edge, even outside the pause/resume catch-up flow.

Both behaviors are disabled by default and can be configured from the options page.

## Motivation

Live streams behave differently from normal on-demand videos. When watching VOD content, a speed above `1x` is stable because the entire timeline is available. On live content, however, speed above `1x` is usually useful only while there is latency to recover.

There are two common cases this PR addresses:

- A user pauses a live stream, resumes behind the live edge, and wants the extension to catch up automatically.
- A user manually watches a live stream faster than `1x`, reaches the live edge, and wants playback to return to normal speed instead of staying in an unnecessary accelerated state.

The implementation keeps these behaviors explicit and opt-in so existing users keep the current behavior unless they enable the new settings.

## User-facing options

This PR adds settings to:

- enable or disable live catch-up
- choose the catch-up playback speed, defaulting to `1.5x`
- choose the latency threshold where catch-up starts, defaulting to `10s` behind live
- choose the live-edge threshold where catch-up stops, defaulting to `3s` behind live
- optionally reset manual speeds above `1x` when a live stream reaches the live edge

## Behavior

### Live stream catch-up

- When a live video is paused close enough to the live edge, the controller records a short-lived catch-up candidate.
- When playback resumes and the video is still behind the configured threshold, the controller temporarily applies the configured catch-up speed.
- Once playback reaches the configured live-edge threshold, catch-up state is cleared and playback returns to `1x` when the temporary catch-up speed was active.
- Manual seeks invalidate pending catch-up state so an intentional jump in the timeline does not accidentally trigger catch-up.
- Manual speed selections remain authoritative outside the pause/resume catch-up flow and are not saved over by the temporary catch-up speed.

### Reset speed at live edge

- When enabled, live streams can reset manual speeds above `1x` back to `1x` after reaching the configured live-edge threshold.
- This behavior is independent from pause/resume catch-up: it applies to manually selected speeds as a separate live-stream convenience.
- It only applies near the live edge and does not change normal on-demand video behavior.

## Implementation notes

- Adds new default settings and options UI for live catch-up and live-edge reset controls.
- Adds live latency detection to the site handler layer.
- Uses YouTube's `movie_player.getProgressState()` and `getVideoData().isLive` when available, because the native media `seekable` range can overstate YouTube live latency.
- Falls back to native media seekable-range heuristics for other live-like media where the timeline indicates a live stream.
- Tracks transient pause/resume/seek state on the video controller instance instead of persisting it.
- Treats the live catch-up speed as authoritative while catch-up is active so the existing ratechange fight-back logic does not immediately undo it.
- Avoids saving the temporary catch-up speed as the user's remembered speed.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- Loaded the built `dist/` extension locally and manually tested the live catch-up flow in the browser.
