### PR TITLE
Fix settings bridge reinitialization and about:blank handling

### DIFF
--- a/src/content/inject.js
+++ b/src/content/inject.js
@@ -193,7 +193,7 @@ class VideoSpeedExtension {
    * non-matching rules never reach the browser's style invalidation engine.
    */
   preprocessDomainCSS(css) {
-    const hostname = location.hostname.replace(/^www\./, '');
+    const hostname = window.VSC.StorageManager.getContextHostname().replace(/^www\./, '');
     return css.replace(
       /:root\[style\*='--vsc-domain:\s*"([^"]+)"'\]([^{]*)\{([^}]*)\}/g,
       (match, domain, selector, body) => (domain === hostname ? `${selector.trim()} {${body}}` : '')

--- a/src/core/settings.js
+++ b/src/core/settings.js
@@ -84,6 +84,7 @@ if (!window.VSC.VideoSpeedConfig) {
           return;
         }
 
+        delete this.settings._abort;
         this._loaded = true;
 
         // Handle key bindings migration/initialization
@@ -125,12 +126,14 @@ if (!window.VSC.VideoSpeedConfig) {
         // Apply siteRules
         this.settings.siteRules =
           storage.siteRules || window.VSC.Constants.DEFAULT_SETTINGS.siteRules;
+        delete this.settings.siteDefaultSpeed;
 
         // Match current URL against site rules to derive per-site default speed.
         // matchSiteRule is exposed on window.VSC by inject-entry.js; guard for
         // test environments where it may not be available.
         if (window.VSC.matchSiteRule) {
-          const matched = window.VSC.matchSiteRule(this.settings.siteRules, window.location.href);
+          const contextUrl = window.VSC.StorageManager.contextUrl || window.location.href;
+          const matched = window.VSC.matchSiteRule(this.settings.siteRules, contextUrl);
           if (matched && matched.speed !== null && matched.speed !== undefined) {
             this.settings.siteDefaultSpeed = matched.speed;
             window.VSC.logger.info(

--- a/src/core/storage-manager.js
+++ b/src/core/storage-manager.js
@@ -15,6 +15,19 @@ if (!window.VSC.StorageManager) {
 
   class StorageManager {
     static errorCallback = null;
+    static contextUrl = window.location.href;
+
+    /**
+     * Resolve the hostname used by site-specific behavior in inherited frames.
+     * @returns {string}
+     */
+    static getContextHostname() {
+      try {
+        return new URL(this.contextUrl, window.location.href).hostname;
+      } catch {
+        return window.location.hostname;
+      }
+    }
 
     /**
      * Register error callback for monitoring storage failures
@@ -50,6 +63,12 @@ if (!window.VSC.StorageManager) {
             window.VSC.logger?.error?.('StorageManager: bridge response is null (clone failed?)');
             resolve(defaults);
             return;
+          }
+
+          // Site rules in inherited about:blank frames must use the creator's
+          // URL rather than window.location.href from the MAIN world.
+          if (typeof detail.contextUrl === 'string' && detail.contextUrl) {
+            this.contextUrl = detail.contextUrl;
           }
 
           // Bridge signals abort for blacklisted/disabled sites

--- a/src/entries/content-bridge.js
+++ b/src/entries/content-bridge.js
@@ -21,59 +21,146 @@ const SPEED_MAX = 16;
 const docEl = document.documentElement;
 let bridgeInitialized = false;
 
+/** @returns {boolean} Whether the URL inherits its creator's origin. */
+function isInheritedAboutUrl(url) {
+  return /^about:(?:blank|srcdoc)(?:[?#].*)?$/.test(url);
+}
+
+/**
+ * Resolve the URL whose site settings should apply to this frame.
+ * Inherited about: frames prefer a non-about referrer and then the first
+ * safely-readable non-about ancestor before falling back to their own URL.
+ *
+ * @returns {string}
+ */
+function resolveContextUrl() {
+  const currentUrl = location.href;
+  if (!isInheritedAboutUrl(currentUrl)) {
+    return currentUrl;
+  }
+
+  if (document.referrer && !isInheritedAboutUrl(document.referrer)) {
+    return document.referrer;
+  }
+
+  try {
+    let ancestor = window.parent;
+    while (ancestor && ancestor !== window) {
+      const ancestorUrl = ancestor.location.href;
+      if (ancestorUrl && !isInheritedAboutUrl(ancestorUrl)) {
+        return ancestorUrl;
+      }
+
+      if (ancestor.parent === ancestor) {
+        break;
+      }
+      ancestor = ancestor.parent;
+    }
+  } catch {
+    // Cross-origin parent access is expected to fail; use the frame URL below.
+  }
+
+  return currentUrl;
+}
+
 async function init() {
   try {
-    // Skip about:blank frames — they share the parent window
-    if (location.href === 'about:blank') {
-      return;
-    }
-
     // Double-injection guard (module-level flag resets on page navigation)
     if (bridgeInitialized) {
       return;
     }
     bridgeInitialized = true;
 
-    const settings = await chrome.storage.sync.get(null);
+    const settings = {};
+    const pendingSettingsChanges = [];
+    let initialSettingsLoaded = false;
+    let hasCompletedSettingsHandshake = false;
+    let bridgeActive = false;
+    let pendingSettingsResponse = false;
 
-    const disabled = settings.enabled === false;
-    // Legacy blacklist: only checked when siteRules hasn't been initialized yet
-    // (pre-migration devices). Once migration runs, siteRules is the source of
-    // truth. The blacklist is preserved in storage for sync compat with older
-    // extension versions but must not shadow siteRules edits.
-    const blacklisted = !settings.siteRules && isBlacklisted(settings.blacklist, location.href);
-    const siteRuleMatch = matchSiteRule(settings.siteRules, location.href);
-    const siteDisabled = siteRuleMatch && siteRuleMatch.enabled === false;
-    const shouldAbort = disabled || blacklisted || siteDisabled;
+    const applySettingsChanges = (changes) => {
+      for (const [key, change] of Object.entries(changes)) {
+        if (change.newValue === undefined) {
+          delete settings[key];
+        } else {
+          settings[key] = change.newValue;
+        }
+      }
+    };
 
-    // Always respond — inject.js runs unconditionally and needs the abort
-    // signal to skip init. { once: true } limits event forgery exposure.
-    if (shouldAbort) {
-      docEl.addEventListener(
-        'VSC_REQUEST_SETTINGS',
-        () => {
-          docEl.dispatchEvent(new CustomEvent('VSC_SETTINGS_READY', { detail: { abort: true } }));
-        },
-        { once: true }
+    // Start loading immediately, but register every bridge listener before it
+    // completes. MAIN can request settings as soon as document_idle fires.
+    const initialSettingsReady = chrome.storage.sync
+      .get(null)
+      .then((storedSettings) => {
+        Object.assign(settings, storedSettings);
+      })
+      .catch((error) => {
+        console.error('[VSC] Initial settings load failed:', error);
+      })
+      .then(() => {
+        for (const changes of pendingSettingsChanges) {
+          applySettingsChanges(changes);
+        }
+        pendingSettingsChanges.length = 0;
+        initialSettingsLoaded = true;
+      });
+
+    const shouldAbortForContext = (contextUrl) => {
+      const disabled = settings.enabled === false;
+      // Legacy blacklist: only checked when siteRules hasn't been initialized yet
+      // (pre-migration devices). Once migration runs, siteRules is the source of
+      // truth. The blacklist is preserved in storage for sync compat with older
+      // extension versions but must not shadow siteRules edits.
+      const blacklisted = !settings.siteRules && isBlacklisted(settings.blacklist, contextUrl);
+      const siteRuleMatch = matchSiteRule(settings.siteRules, contextUrl);
+      const siteDisabled = siteRuleMatch && siteRuleMatch.enabled === false;
+      return disabled || blacklisted || siteDisabled;
+    };
+
+    const respondWithSettings = () => {
+      const contextUrl = resolveContextUrl();
+      hasCompletedSettingsHandshake = true;
+
+      if (shouldAbortForContext(contextUrl)) {
+        bridgeActive = false;
+        docEl.dispatchEvent(
+          new CustomEvent('VSC_SETTINGS_READY', { detail: { abort: true, contextUrl } })
+        );
+        return;
+      }
+
+      // Strip keys the MAIN world shouldn't see without mutating the snapshot.
+      const publicSettings = { ...settings };
+      delete publicSettings.blacklist;
+      delete publicSettings.enabled;
+      bridgeActive = true;
+      docEl.dispatchEvent(
+        new CustomEvent('VSC_SETTINGS_READY', {
+          detail: { settings: publicSettings, contextUrl },
+        })
       );
-      return;
-    }
+    };
 
-    const hostname = location.hostname.replace(/^www\./, '');
+    // Keep this listener reusable. Reinitialization in MAIN world performs a
+    // fresh handshake, and the settings snapshot below is updated by onChanged.
+    docEl.addEventListener('VSC_REQUEST_SETTINGS', () => {
+      if (initialSettingsLoaded) {
+        respondWithSettings();
+        return;
+      }
 
-    // Strip keys the MAIN world shouldn't see
-    delete settings.blacklist;
-    delete settings.enabled;
-
-    const settingsPayload = { settings, hostname };
-
-    docEl.addEventListener(
-      'VSC_REQUEST_SETTINGS',
-      () => {
-        docEl.dispatchEvent(new CustomEvent('VSC_SETTINGS_READY', { detail: settingsPayload }));
-      },
-      { once: true }
-    );
+      // The event channel has no request ID, so coalesce requests while the
+      // initial read is pending. One response resolves every active listener
+      // and cannot leave an older response to be consumed by a later reload.
+      if (!pendingSettingsResponse) {
+        pendingSettingsResponse = true;
+        initialSettingsReady.then(() => {
+          pendingSettingsResponse = false;
+          respondWithSettings();
+        });
+      }
+    });
 
     // --- Ongoing: storage change relay + lifecycle ---
     chrome.storage.onChanged.addListener((changes, namespace) => {
@@ -81,15 +168,31 @@ async function init() {
         return;
       }
 
+      // Preserve changes that race the initial storage read, then keep the
+      // response snapshot current before dispatching lifecycle events.
+      if (initialSettingsLoaded) {
+        applySettingsChanges(changes);
+      } else {
+        pendingSettingsChanges.push(changes);
+      }
+
       // Lifecycle: only the popup's enabled toggle triggers teardown/reinit.
       // Options page never writes `enabled`, so saving options can't trigger
       // lifecycle — it only relays settings via VSC_STORAGE_CHANGED below.
       // siteRules/blacklist changes take effect on next page load.
       if (changes.enabled?.newValue === false) {
+        bridgeActive = false;
         docEl.dispatchEvent(new CustomEvent('VSC_MESSAGE', { detail: { type: 'VSC_TEARDOWN' } }));
         return;
       }
-      if (changes.enabled?.oldValue === false && changes.enabled?.newValue !== false) {
+      if (
+        hasCompletedSettingsHandshake &&
+        changes.enabled?.oldValue === false &&
+        changes.enabled?.newValue !== false
+      ) {
+        // Stay inactive until the reinitializing MAIN world completes a fresh
+        // settings handshake (which may still abort due to a site rule).
+        bridgeActive = false;
         docEl.dispatchEvent(new CustomEvent('VSC_MESSAGE', { detail: { type: 'VSC_REINIT' } }));
       }
 
@@ -104,12 +207,19 @@ async function init() {
 
     // --- Ongoing: popup/background message relay ---
     chrome.runtime.onMessage.addListener((request) => {
+      if (!initialSettingsLoaded || !bridgeActive) {
+        return;
+      }
       docEl.dispatchEvent(new CustomEvent('VSC_MESSAGE', { detail: request }));
     });
 
     // --- Ongoing: speed write-back from MAIN world ---
     const handleWriteStorage = (e) => {
       try {
+        if (!initialSettingsLoaded || !bridgeActive) {
+          return;
+        }
+
         const data = e.detail;
         if (!data || typeof data !== 'object') {
           return;

--- a/src/site-handlers/amazon-handler.js
+++ b/src/site-handlers/amazon-handler.js
@@ -9,12 +9,12 @@ class AmazonHandler extends window.VSC.BaseSiteHandler {
    * Check if this handler applies to Amazon
    * @returns {boolean} True if on Amazon
    */
-  static matches() {
+  static matches(hostname = location.hostname) {
     return (
-      location.hostname === 'www.amazon.com' ||
-      location.hostname === 'www.primevideo.com' ||
-      location.hostname.includes('amazon.') ||
-      location.hostname.includes('primevideo.')
+      hostname === 'www.amazon.com' ||
+      hostname === 'www.primevideo.com' ||
+      hostname.includes('amazon.') ||
+      hostname.includes('primevideo.')
     );
   }
 

--- a/src/site-handlers/apple-handler.js
+++ b/src/site-handlers/apple-handler.js
@@ -9,8 +9,8 @@ class AppleHandler extends window.VSC.BaseSiteHandler {
    * Check if this handler applies to Apple TV+
    * @returns {boolean} True if on Apple TV+
    */
-  static matches() {
-    return location.hostname === 'tv.apple.com';
+  static matches(hostname = location.hostname) {
+    return hostname === 'tv.apple.com';
   }
 
   /**

--- a/src/site-handlers/base-handler.js
+++ b/src/site-handlers/base-handler.js
@@ -5,8 +5,8 @@
 window.VSC = window.VSC || {};
 
 class BaseSiteHandler {
-  constructor() {
-    this.hostname = location.hostname;
+  constructor(hostname = location.hostname) {
+    this.hostname = hostname;
   }
 
   /**

--- a/src/site-handlers/dailymotion-handler.js
+++ b/src/site-handlers/dailymotion-handler.js
@@ -11,8 +11,8 @@
 window.VSC = window.VSC || {};
 
 class DailymotionHandler extends window.VSC.BaseSiteHandler {
-  static matches() {
-    return location.hostname.includes('dailymotion.com');
+  static matches(hostname = location.hostname) {
+    return hostname.includes('dailymotion.com');
   }
 
   getControllerPosition(parent, _video) {

--- a/src/site-handlers/facebook-handler.js
+++ b/src/site-handlers/facebook-handler.js
@@ -9,8 +9,8 @@ class FacebookHandler extends window.VSC.BaseSiteHandler {
    * Check if this handler applies to Facebook
    * @returns {boolean} True if on Facebook
    */
-  static matches() {
-    return location.hostname === 'www.facebook.com';
+  static matches(hostname = location.hostname) {
+    return hostname === 'www.facebook.com';
   }
 
   /**

--- a/src/site-handlers/frame-handler.js
+++ b/src/site-handlers/frame-handler.js
@@ -11,8 +11,8 @@
 window.VSC = window.VSC || {};
 
 class FrameHandler extends window.VSC.BaseSiteHandler {
-  static matches() {
-    return location.hostname === 'next.frame.io';
+  static matches(hostname = location.hostname) {
+    return hostname === 'next.frame.io';
   }
 
   getControllerPosition(parent, video) {

--- a/src/site-handlers/index.js
+++ b/src/site-handlers/index.js
@@ -35,15 +35,16 @@ class SiteHandlerManager {
    * @private
    */
   detectHandler() {
+    const hostname = window.VSC.StorageManager.getContextHostname();
     for (const HandlerClass of this.availableHandlers) {
-      if (HandlerClass.matches()) {
-        window.VSC.logger.info(`Using ${HandlerClass.name} for ${location.hostname}`);
-        return new HandlerClass();
+      if (HandlerClass.matches(hostname)) {
+        window.VSC.logger.info(`Using ${HandlerClass.name} for ${hostname}`);
+        return new HandlerClass(hostname);
       }
     }
 
-    window.VSC.logger.debug(`Using BaseSiteHandler for ${location.hostname}`);
-    return new window.VSC.BaseSiteHandler();
+    window.VSC.logger.debug(`Using BaseSiteHandler for ${hostname}`);
+    return new window.VSC.BaseSiteHandler(hostname);
   }
 
   /**

--- a/src/site-handlers/netflix-handler.js
+++ b/src/site-handlers/netflix-handler.js
@@ -9,8 +9,8 @@ class NetflixHandler extends window.VSC.BaseSiteHandler {
    * Check if this handler applies to Netflix
    * @returns {boolean} True if on Netflix
    */
-  static matches() {
-    return location.hostname === 'www.netflix.com';
+  static matches(hostname = location.hostname) {
+    return hostname === 'www.netflix.com';
   }
 
   /**

--- a/src/site-handlers/youtube-handler.js
+++ b/src/site-handlers/youtube-handler.js
@@ -9,8 +9,8 @@ class YouTubeHandler extends window.VSC.BaseSiteHandler {
    * Check if this handler applies to YouTube
    * @returns {boolean} True if on YouTube
    */
-  static matches() {
-    return location.hostname === 'www.youtube.com';
+  static matches(hostname = location.hostname) {
+    return hostname === 'www.youtube.com';
   }
 
   /**

--- a/tests/integration/module-integration.test.js
+++ b/tests/integration/module-integration.test.js
@@ -18,6 +18,8 @@ describe('ModuleIntegration', () => {
   });
 
   afterEach(() => {
+    window.VSC.StorageManager.contextUrl = window.location.href;
+    window.VSC.siteHandlerManager.refresh();
     cleanupChromeMock();
     if (mockDOM) {
       mockDOM.cleanup();
@@ -48,6 +50,16 @@ describe('ModuleIntegration', () => {
     const positioning = siteHandlerManager.getControllerPosition(mockDOM.container, mockVideo);
     expect(positioning).toBeDefined();
     expect(positioning.insertionPoint).toBeDefined();
+  });
+
+  it('selects site handlers using an inherited frame context hostname', () => {
+    window.VSC.StorageManager.contextUrl = 'https://www.youtube.com/watch?v=test';
+    window.VSC.siteHandlerManager.refresh();
+
+    const handler = window.VSC.siteHandlerManager.getCurrentHandler();
+
+    expect(handler).toBeInstanceOf(window.VSC.YouTubeHandler);
+    expect(handler.hostname).toBe('www.youtube.com');
   });
 
   it('Settings should integrate with ActionHandler', async () => {

--- a/tests/unit/content/content-bridge.test.js
+++ b/tests/unit/content/content-bridge.test.js
@@ -6,7 +6,7 @@
  *   - Blacklist correctness: domain-boundary matching, invalid regex handling
  *   - Settings handshake: request/response protocol
  *   - Lifecycle: teardown/reinit dispatch on storage changes
- *   - Early exit: disabled/blacklisted sites skip initialization
+ *   - Disabled/blacklisted sites abort MAIN-world initialization
  *
  * The bridge auto-inits at module load. Each test uses vi.resetModules() +
  * dynamic import for fresh state. Chrome mock must be configured BEFORE import.
@@ -123,6 +123,7 @@ describe('content-bridge', () => {
       cleanupIntercept = null;
     }
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.useRealTimers();
     cleanupChromeMock();
   });
@@ -217,7 +218,7 @@ describe('content-bridge', () => {
       expect(events[0].detail.settings.rememberSpeed).toBe(true);
     });
 
-    it('strips sensitive keys, passes customCSS, includes hostname', async () => {
+    it('strips sensitive keys, passes customCSS, and includes contextUrl', async () => {
       getMockStorage().blacklist = 'some.site';
       getMockStorage().enabled = true;
       getMockStorage().customCSS = 'vsc-controller { top: 42px; }';
@@ -228,14 +229,129 @@ describe('content-bridge', () => {
 
       docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
 
-      const { settings, hostname } = events[0].detail;
+      const { settings, contextUrl } = events[0].detail;
       // Stripped from settings
       expect(settings.blacklist).toBeUndefined();
       expect(settings.enabled).toBeUndefined();
       // customCSS passes through (inject.js reads it from config.settings)
       expect(settings.customCSS).toBe('vsc-controller { top: 42px; }');
-      expect(typeof hostname).toBe('string');
+      expect(contextUrl).toBe(window.location.href);
     });
+
+    it('responds to every settings request with the latest storage values', async () => {
+      getMockStorage().customCSS = 'vsc-controller { top: 1px; }';
+      await loadBridge();
+
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY');
+      eventCleanup = cleanup;
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      expect(events).toHaveLength(1);
+      expect(events[0].detail.settings.customCSS).toContain('top: 1px');
+
+      globalThis.chrome.storage.sync.set({
+        customCSS: 'vsc-controller { top: 2px; }',
+        keyBindings: [{ action: 'faster', key: 68, value: 0.25 }],
+      });
+      await vi.advanceTimersByTimeAsync(20);
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      expect(events).toHaveLength(2);
+      expect(events[1].detail.settings.customCSS).toContain('top: 2px');
+      expect(events[1].detail.settings.keyBindings[0].value).toBe(0.25);
+    });
+
+    it('does not lose a settings request while the initial storage read is pending', async () => {
+      let resolveSettings;
+      vi.spyOn(globalThis.chrome.storage.sync, 'get').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSettings = resolve;
+          })
+      );
+
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY');
+      eventCleanup = cleanup;
+      vi.resetModules();
+      await import('../../../src/entries/content-bridge.js');
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      expect(events).toHaveLength(0);
+
+      resolveSettings({ ...getMockStorage(), customCSS: 'vsc-controller { top: 9px; }' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail.settings.customCSS).toContain('top: 9px');
+    });
+
+    it('coalesces settings requests while the initial storage read is pending', async () => {
+      let resolveSettings;
+      vi.spyOn(globalThis.chrome.storage.sync, 'get').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSettings = resolve;
+          })
+      );
+
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY');
+      eventCleanup = cleanup;
+      vi.resetModules();
+      await import('../../../src/entries/content-bridge.js');
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      resolveSettings({ ...getMockStorage(), customCSS: 'vsc-controller { top: 9px; }' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].detail.settings.customCSS).toContain('top: 9px');
+    });
+
+    it('resolves the current URL again for each settings request', async () => {
+      let href = 'https://example.test/course/a';
+      vi.stubGlobal('location', {
+        get href() {
+          return href;
+        },
+        hostname: 'example.test',
+      });
+      await loadBridge();
+
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY');
+      eventCleanup = cleanup;
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      href = 'https://example.test/course/b';
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(events.map((event) => event.detail.contextUrl)).toEqual([
+        'https://example.test/course/a',
+        'https://example.test/course/b',
+      ]);
+    });
+
+    it.each(['about:blank', 'about:blank#child', 'about:srcdoc'])(
+      'inherits site rules for %s from document.referrer',
+      async (frameUrl) => {
+        vi.stubGlobal('location', { href: frameUrl, hostname: '' });
+        vi.spyOn(document, 'referrer', 'get').mockReturnValue('https://parent.example/video');
+        getMockStorage().siteRules = [{ pattern: 'parent.example', enabled: false, speed: null }];
+
+        const { events, cleanup } = collectEvents('VSC_SETTINGS_READY');
+        eventCleanup = cleanup;
+        await loadBridge();
+
+        docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+
+        expect(events).toHaveLength(1);
+        expect(events[0].detail).toEqual({
+          abort: true,
+          contextUrl: 'https://parent.example/video',
+        });
+      }
+    );
   });
 
   // =========================================================================
@@ -246,6 +362,7 @@ describe('content-bridge', () => {
     it('writes valid lastSpeed to chrome.storage and clamps to range', async () => {
       await loadBridge();
       const storage = getMockStorage();
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
 
       // Valid speed
       docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: { lastSpeed: 2.5 } }));
@@ -267,6 +384,7 @@ describe('content-bridge', () => {
       await loadBridge();
       const storage = getMockStorage();
       const originalSpeed = storage.lastSpeed;
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
 
       // Non-number
       docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: { lastSpeed: 'fast' } }));
@@ -287,6 +405,24 @@ describe('content-bridge', () => {
       docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: null }));
       await vi.advanceTimersByTimeAsync(20);
       expect(storage.lastSpeed).toBe(originalSpeed);
+    });
+
+    it('blocks writes while disabled and accepts them after re-enable', async () => {
+      getMockStorage().enabled = false;
+      const onChanged = await loadBridge();
+      const storage = getMockStorage();
+      const originalSpeed = storage.lastSpeed;
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: { lastSpeed: 2.5 } }));
+      await vi.advanceTimersByTimeAsync(20);
+      expect(storage.lastSpeed).toBe(originalSpeed);
+
+      onChanged({ enabled: { oldValue: false, newValue: true } }, 'sync');
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: { lastSpeed: 2.5 } }));
+      await vi.advanceTimersByTimeAsync(20);
+      expect(storage.lastSpeed).toBe(2.5);
     });
   });
 
@@ -311,13 +447,133 @@ describe('content-bridge', () => {
     });
 
     it('dispatches VSC_REINIT when re-enabled via popup toggle', async () => {
+      getMockStorage().enabled = false;
       const onChanged = await loadBridge();
-      const { events, cleanup } = collectEvents('VSC_MESSAGE');
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY', 'VSC_MESSAGE');
       eventCleanup = cleanup;
 
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
       onChanged({ enabled: { oldValue: false, newValue: true } }, 'sync');
       const reinits = events.filter((e) => e.detail?.type === 'VSC_REINIT');
       expect(reinits).toHaveLength(1);
+    });
+
+    it('re-enables after an initially-disabled load with current custom settings', async () => {
+      getMockStorage().enabled = false;
+      getMockStorage().customCSS = 'vsc-controller { top: 1px; }';
+      const onChanged = await loadBridge();
+      expect(onChanged).not.toBeNull();
+
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY', 'VSC_MESSAGE');
+      eventCleanup = cleanup;
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      expect(events[0].detail.abort).toBe(true);
+
+      globalThis.chrome.storage.sync.set({
+        enabled: true,
+        customCSS: 'vsc-controller { top: 42px; }',
+        keyBindings: [{ action: 'faster', key: 68, value: 0.5 }],
+      });
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(events.some((event) => event.detail?.type === 'VSC_REINIT')).toBe(true);
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      const readyEvents = events.filter((event) => event.type === 'VSC_SETTINGS_READY');
+      expect(readyEvents).toHaveLength(2);
+      expect(readyEvents[1].detail.settings.customCSS).toContain('top: 42px');
+      expect(readyEvents[1].detail.settings.keyBindings[0].value).toBe(0.5);
+      expect(readyEvents[1].detail.settings.enabled).toBeUndefined();
+      expect(readyEvents[1].detail.settings.blacklist).toBeUndefined();
+    });
+
+    it('does not dispatch a duplicate reinit while the first handshake is pending', async () => {
+      let resolveSettings;
+      vi.spyOn(globalThis.chrome.storage.sync, 'get').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveSettings = resolve;
+          })
+      );
+
+      let onChanged;
+      vi.spyOn(globalThis.chrome.storage.onChanged, 'addListener').mockImplementation(
+        (listener) => {
+          onChanged = listener;
+        }
+      );
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY', 'VSC_MESSAGE');
+      eventCleanup = cleanup;
+
+      vi.resetModules();
+      await import('../../../src/entries/content-bridge.js');
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      onChanged({ enabled: { oldValue: false, newValue: true } }, 'sync');
+
+      expect(events.some((event) => event.detail?.type === 'VSC_REINIT')).toBe(false);
+
+      resolveSettings({ ...getMockStorage(), enabled: false });
+      await vi.advanceTimersByTimeAsync(0);
+
+      const readyEvents = events.filter((event) => event.type === 'VSC_SETTINGS_READY');
+      expect(readyEvents).toHaveLength(1);
+      expect(readyEvents[0].detail.abort).toBeUndefined();
+      expect(events.some((event) => event.detail?.type === 'VSC_REINIT')).toBe(false);
+    });
+
+    it('keeps runtime message relay registered but blocks it until re-enabled', async () => {
+      getMockStorage().enabled = false;
+      let runtimeMessageListener;
+      vi.spyOn(globalThis.chrome.runtime.onMessage, 'addListener').mockImplementation(
+        (listener) => {
+          runtimeMessageListener = listener;
+        }
+      );
+      const onChanged = await loadBridge();
+      const { events, cleanup } = collectEvents('VSC_MESSAGE');
+      eventCleanup = cleanup;
+      const request = { type: 'VSC_SET_SPEED', payload: { speed: 2 } };
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      runtimeMessageListener(request);
+      expect(events.some((event) => event.detail?.type === request.type)).toBe(false);
+
+      onChanged({ enabled: { oldValue: false, newValue: true } }, 'sync');
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      runtimeMessageListener(request);
+      expect(events.filter((event) => event.detail?.type === request.type)).toHaveLength(1);
+    });
+
+    it('keeps the active bridge live until reload after a site-rule change', async () => {
+      let runtimeMessageListener;
+      vi.spyOn(globalThis.chrome.runtime.onMessage, 'addListener').mockImplementation(
+        (listener) => {
+          runtimeMessageListener = listener;
+        }
+      );
+      const onChanged = await loadBridge();
+      const { events, cleanup } = collectEvents('VSC_SETTINGS_READY', 'VSC_MESSAGE');
+      eventCleanup = cleanup;
+      const request = { type: 'VSC_SET_SPEED', payload: { speed: 2 } };
+
+      docEl.dispatchEvent(new CustomEvent('VSC_REQUEST_SETTINGS'));
+      onChanged(
+        {
+          siteRules: {
+            oldValue: [],
+            newValue: [{ pattern: 'localhost', enabled: false, speed: null }],
+          },
+        },
+        'sync'
+      );
+
+      runtimeMessageListener(request);
+      docEl.dispatchEvent(new CustomEvent('VSC_WRITE_STORAGE', { detail: { lastSpeed: 2.5 } }));
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(events.filter((event) => event.detail?.type === request.type)).toHaveLength(1);
+      expect(getMockStorage().lastSpeed).toBe(2.5);
     });
 
     it('does NOT lifecycle on blacklist changes (takes effect on reload)', async () => {
@@ -396,9 +652,4 @@ describe('content-bridge', () => {
       expect(events[0].detail.blacklist).toBeUndefined();
     });
   });
-
-  // Runtime message relay: chrome mock doesn't expose onMessage listeners,
-  // so we can't unit-test the relay without enhancing the mock. The relay is
-  // a trivial one-liner (line 119 of content-bridge.js) — tested via manual
-  // popup interaction rather than unit tests.
 });

--- a/tests/unit/core/controller-css.test.js
+++ b/tests/unit/core/controller-css.test.js
@@ -26,6 +26,7 @@ describe('ControllerCSS', () => {
   });
 
   afterEach(() => {
+    window.VSC.StorageManager.contextUrl = window.location.href;
     cleanupChromeMock();
   });
 
@@ -51,6 +52,16 @@ describe('ControllerCSS', () => {
     expect(css.includes('--vsc-domain: "netflix.com"')).toBe(true);
     expect(css.includes('--vsc-domain: "chatgpt.com"')).toBe(true);
     expect(css.includes('--vsc-domain: "drive.google.com"')).toBe(true);
+  });
+
+  it('preprocesses domain CSS using an inherited frame context hostname', () => {
+    window.VSC.StorageManager.contextUrl = 'https://www.netflix.com/watch/123';
+    const processed = window.VSC_controller.preprocessDomainCSS(
+      window.VSC.Constants.DEFAULT_CONTROLLER_CSS
+    );
+
+    expect(processed).toContain('vsc-controller {\n  position: relative;\n  top: 85px;');
+    expect(processed).not.toContain('--vsc-domain: "netflix.com"');
   });
 
   it('inject.css pins the absolute controller host origin', () => {

--- a/tests/unit/core/settings.test.js
+++ b/tests/unit/core/settings.test.js
@@ -18,6 +18,7 @@ describe('Settings', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     installChromeMock();
     resetMockStorage();
+    window.VSC.StorageManager.contextUrl = window.location.href;
   });
 
   afterEach(() => {
@@ -217,6 +218,55 @@ describe('Settings', () => {
     expect(config.settings.siteDefaultSpeed).toBe(2.3);
 
     window.VSC.matchSiteRule = original;
+  });
+
+  it('matches site speed against StorageManager contextUrl', async () => {
+    const config = new window.VSC.VideoSpeedConfig();
+    const original = window.VSC.matchSiteRule;
+    const inheritedUrl = 'https://parent.example/video';
+    const matchSiteRule = vi.fn(() => ({
+      pattern: 'parent.example',
+      enabled: true,
+      speed: 2.3,
+    }));
+    window.VSC.StorageManager.contextUrl = inheritedUrl;
+    window.VSC.matchSiteRule = matchSiteRule;
+
+    await config.load();
+
+    expect(matchSiteRule).toHaveBeenCalledWith(config.settings.siteRules, inheritedUrl);
+    expect(config.settings.siteDefaultSpeed).toBe(2.3);
+
+    window.VSC.matchSiteRule = original;
+  });
+
+  it('clears an initial abort and loads current custom settings after re-enable', async () => {
+    const config = new window.VSC.VideoSpeedConfig();
+    const defaults = {
+      ...window.VSC.Constants.DEFAULT_SETTINGS,
+      controllerCSS: null,
+    };
+    const keyBindings = defaults.keyBindings.map((binding) =>
+      binding.action === 'faster' ? { ...binding, value: 0.25 } : binding
+    );
+    const getSpy = vi
+      .spyOn(window.VSC.StorageManager, 'get')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        ...defaults,
+        customCSS: 'vsc-controller { top: 42px; }',
+        keyBindings,
+      });
+
+    await config.load();
+    expect(config.settings._abort).toBe(true);
+
+    await config.load();
+    expect(config.settings._abort).toBeUndefined();
+    expect(config.settings.customCSS).toContain('top: 42px');
+    expect(config.getKeyBinding('faster')).toBe(0.25);
+
+    getSpy.mockRestore();
   });
 
   it('siteDefaultSpeed is not set when siteRule matches with speed=null', async () => {

--- a/tests/unit/core/storage-manager-main-world.test.js
+++ b/tests/unit/core/storage-manager-main-world.test.js
@@ -122,6 +122,34 @@ describe('StorageManager — MAIN world (CustomEvent paths)', () => {
 
       docEl.removeEventListener('VSC_REQUEST_SETTINGS', responder);
     });
+
+    it('retains contextUrl from successful and aborted bridge responses', async () => {
+      const contextUrls = ['https://parent.example/video', 'https://blocked.example/video'];
+      let requestCount = 0;
+      const responder = () => {
+        const contextUrl = contextUrls[requestCount++];
+        docEl.dispatchEvent(
+          new CustomEvent('VSC_SETTINGS_READY', {
+            detail:
+              requestCount === 1
+                ? { settings: { lastSpeed: 2.0 }, contextUrl }
+                : { abort: true, contextUrl },
+          })
+        );
+      };
+      docEl.addEventListener('VSC_REQUEST_SETTINGS', responder);
+
+      const settings = await StorageManager.get({ lastSpeed: 1.0 });
+      expect(settings.lastSpeed).toBe(2.0);
+      expect(StorageManager.contextUrl).toBe(contextUrls[0]);
+      expect(StorageManager.getContextHostname()).toBe('parent.example');
+
+      const aborted = await StorageManager.get({ lastSpeed: 1.0 });
+      expect(aborted).toBeNull();
+      expect(StorageManager.contextUrl).toBe(contextUrls[1]);
+
+      docEl.removeEventListener('VSC_REQUEST_SETTINGS', responder);
+    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep the isolated-world settings bridge available across disable/re-enable cycles
- answer every settings handshake with the current sanitized settings snapshot
- evaluate disabled-site rules and per-site speed against the creator URL for inherited `about:` frames
- use that inherited context for domain CSS and site-handler selection as well
- avoid early-handshake and re-enable races, and block runtime relays/storage writes while inactive

## Testing

- `npm ci`
- `npm run lint`
- `npm run build:release`
- `npm test` (31 files, 396 tests)
- independent diff review and Codex second-opinion review

## Notes

- No manifest permissions changed.
- `npm audit --audit-level=high` reports the same existing 9 advisories (4 high) on `upstream/master` and this branch; dependency updates are intentionally out of scope.
