### PR TITLE
Model extension file access in Chrome E2E

### DIFF
--- a/tests/e2e/e2e-utils.js
+++ b/tests/e2e/e2e-utils.js
@@ -41,6 +41,8 @@ export async function launchChromeWithExtension() {
         '--disable-ipc-flooding-protection',
         '--window-size=1280,720',
         '--allow-file-access-from-files',
+        // Simulate the user-enabled "Allow access to file URLs" extension setting.
+        '--disable-extensions-file-access-check',
       ],
       ignoreDefaultArgs: ['--disable-extensions', '--enable-automation'],
     });


### PR DESCRIPTION
## Summary

- Keep the existing file-origin access flag used by the browser fixtures.
- Add Chromium's extension-specific test switch so E2E runs model the user-enabled **Allow access to file URLs** setting.
- Keep runtime code, manifest permissions, and product behavior unchanged.

## Why

The E2E suite loads `file://` fixtures, but `--allow-file-access-from-files` does not disable Chromium's separate user opt-in check for extensions injecting into file URLs. `--disable-extensions-file-access-check` is Chromium's test switch for that extension-specific permission path.

Chromium source: https://chromium.googlesource.com/chromium/src/+/main/chrome/common/chrome_switches.cc

## Testing

- `npm ci`
- `npm run lint`
- `npm run build:release`
- `npm test` (43 files, 534 tests)
- `npm run test:e2e -- basic` (10/10 passed)
- Codex second-opinion review (no actionable findings)

## GitHub Actions

The upstream CI run is awaiting repository-maintainer approval for a workflow from a fork. GitHub has not started any jobs yet: https://github.com/igrigorik/videospeed/actions/runs/30735334595

## Notes

- One file changed; no production code or manifest permissions changed.
- Both flags are retained because they model separate file-origin and extension opt-in checks.
